### PR TITLE
remove type annotation model backwards compability - None is not list

### DIFF
--- a/src/dataset/model_backwards_compatibility.py
+++ b/src/dataset/model_backwards_compatibility.py
@@ -254,7 +254,7 @@ def handle_version_3_1_0(supplied_metadata: dict[str, Any]) -> dict[str, Any]:
     Returns:
         The updated metadata dictionary.
     """
-    data: list = supplied_metadata["datadoc"]["dataset"]["data_source"]
+    data = supplied_metadata["datadoc"]["dataset"]["data_source"]
 
     if data is not None:
         supplied_metadata["datadoc"]["dataset"]["data_source"] = str(


### PR DESCRIPTION
[remove type annotation model backwards compability - None is not list](https://github.com/statisticsnorway/dapla-toolbelt-metadata/commit/e13cf51be97a327518f4fe5b7718c14f557feb8f)