### PR TITLE
Also accept dash in SSB format date strings

### DIFF
--- a/src/dapla_metadata/datasets/dapla_dataset_path_info.py
+++ b/src/dapla_metadata/datasets/dapla_dataset_path_info.py
@@ -141,6 +141,9 @@ class SsbDateFormat(DateFormat):
 
             >>> SSB_BIMESTER.get_floor("2003B4")
             datetime.date(2003, 7, 1)
+
+            >>> SSB_BIMESTER.get_floor("2003-B4")
+            datetime.date(2003, 7, 1)
         """
         try:
             year = period_string[:4]
@@ -170,6 +173,9 @@ class SsbDateFormat(DateFormat):
 
             >>> SSB_HALF_YEAR.get_ceil("2024H1")
             datetime.date(2024, 6, 30)
+
+            >>> SSB_HALF_YEAR.get_ceil("2024-H1")
+            datetime.date(2024, 6, 30)
         """
         try:
             year = period_string[:4]
@@ -182,7 +188,7 @@ class SsbDateFormat(DateFormat):
 
 SSB_BIMESTER = SsbDateFormat(
     name="SSB_BIMESTER",
-    regex_pattern=r"^\d{4}[B]\d{1}$",
+    regex_pattern=r"^\d{4}-?[B]\d{1}$",
     arrow_pattern="YYYYMM",
     timeframe="month",
     ssb_dates={
@@ -215,7 +221,7 @@ SSB_BIMESTER = SsbDateFormat(
 
 SSB_QUARTERLY = SsbDateFormat(
     name="SSB_QUARTERLY",
-    regex_pattern=r"^\d{4}[Q]\d{1}$",
+    regex_pattern=r"^\d{4}-?[Q]\d{1}$",
     arrow_pattern="YYYYMM",
     timeframe="month",
     ssb_dates={
@@ -240,7 +246,7 @@ SSB_QUARTERLY = SsbDateFormat(
 
 SSB_TRIANNUAL = SsbDateFormat(
     name="SSB_TRIANNUAL",
-    regex_pattern=r"^\d{4}[T]\d{1}$",
+    regex_pattern=r"^\d{4}-?[T]\d{1}$",
     arrow_pattern="YYYYMM",
     timeframe="month",
     ssb_dates={
@@ -260,7 +266,7 @@ SSB_TRIANNUAL = SsbDateFormat(
 )
 SSB_HALF_YEAR = SsbDateFormat(
     name="SSB_HALF_YEAR",
-    regex_pattern=r"^\d{4}[H]\d{1}$",
+    regex_pattern=r"^\d{4}-?[H]\d{1}$",
     arrow_pattern="YYYYMM",
     timeframe="month",
     ssb_dates={
@@ -412,6 +418,9 @@ class DaplaDatasetPathInfo:
 
             >>> DaplaDatasetPathInfo._extract_period_strings(['p1990Q1', 'kommune', 'v1'])
             ['1990Q1']
+
+            >>> DaplaDatasetPathInfo._extract_period_strings(['p1990-Q1', 'kommune', 'v1'])
+            ['1990-Q1']
 
             >>> DaplaDatasetPathInfo._extract_period_strings(['varehandel','v1'])
             []

--- a/src/dapla_metadata/datasets/dapla_dataset_path_info.py
+++ b/src/dapla_metadata/datasets/dapla_dataset_path_info.py
@@ -586,6 +586,9 @@ class DaplaDatasetPathInfo:
             >>> DaplaDatasetPathInfo('klargjorte_data/person_data_v1.parquet').dataset_state
             <DataSetState.PROCESSED_DATA: 'PROCESSED_DATA'>
 
+            >>> DaplaDatasetPathInfo('klargjorte-data/person_data_v1.parquet').dataset_state
+            <DataSetState.PROCESSED_DATA: 'PROCESSED_DATA'>
+
             >>> DaplaDatasetPathInfo('utdata/min_statistikk/person_data_v1.parquet').dataset_state
             <DataSetState.OUTPUT_DATA: 'OUTPUT_DATA'>
 

--- a/tests/datasets/test_dapla_dataset_path_info.py
+++ b/tests/datasets/test_dapla_dataset_path_info.py
@@ -70,7 +70,17 @@ TEST_CASES = [
         expected_contains_data_until=datetime.date(2022, 6, 30),
     ),
     DatasetPathTestCase(
+        path="personinntekt_p2022-H1_v1.parquet",
+        expected_contains_data_from=datetime.date(2022, 1, 1),
+        expected_contains_data_until=datetime.date(2022, 6, 30),
+    ),
+    DatasetPathTestCase(
         path="nybilreg_p2022T1_v1.parquet",
+        expected_contains_data_from=datetime.date(2022, 1, 1),
+        expected_contains_data_until=datetime.date(2022, 4, 30),
+    ),
+    DatasetPathTestCase(
+        path="nybilreg_p2022-T1_v1.parquet",
         expected_contains_data_from=datetime.date(2022, 1, 1),
         expected_contains_data_until=datetime.date(2022, 4, 30),
     ),
@@ -80,7 +90,17 @@ TEST_CASES = [
         expected_contains_data_until=datetime.date(2018, 12, 31),
     ),
     DatasetPathTestCase(
+        path="varehandel_p2018-Q1_p2018-Q4_v1.parquet",
+        expected_contains_data_from=datetime.date(2018, 1, 1),
+        expected_contains_data_until=datetime.date(2018, 12, 31),
+    ),
+    DatasetPathTestCase(
         path="pensjon_p2018Q1_v1.parquet",
+        expected_contains_data_from=datetime.date(2018, 1, 1),
+        expected_contains_data_until=datetime.date(2018, 3, 31),
+    ),
+    DatasetPathTestCase(
+        path="pensjon_p2018-Q1_v1.parquet",
         expected_contains_data_from=datetime.date(2018, 1, 1),
         expected_contains_data_until=datetime.date(2018, 3, 31),
     ),
@@ -90,7 +110,17 @@ TEST_CASES = [
         expected_contains_data_until=datetime.date(2021, 4, 30),
     ),
     DatasetPathTestCase(
+        path="skipsanloep_p2021-B2_v1.parquet",
+        expected_contains_data_from=datetime.date(2021, 3, 1),
+        expected_contains_data_until=datetime.date(2021, 4, 30),
+    ),
+    DatasetPathTestCase(
         path="skipsanloep_p2022B1_v1.parquet",
+        expected_contains_data_from=datetime.date(2022, 1, 1),
+        expected_contains_data_until=datetime.date(2022, 2, 28),
+    ),
+    DatasetPathTestCase(
+        path="skipsanloep_p2022-B1_v1.parquet",
         expected_contains_data_from=datetime.date(2022, 1, 1),
         expected_contains_data_until=datetime.date(2022, 2, 28),
     ),


### PR DESCRIPTION
## Background

Relevant specification: https://statistics-norway.atlassian.net/wiki/spaces/MPD/pages/2953084957/Standardformater#SSBs-egne-dato-formater-for-periodeinndeling-av-et-%C3%A5r

These changes are made following a decision on naming standard updates on 30.09.2024. Changes to documentation in the Dapla Manual and on Confluence to come.

Changes are additive so will not break any existing files or workflows.

## Summary of changes

- **Add test for klargjorte-data format**
- **Add failing test cases with dash in SSB date formats**
- **Also accept dash in SSB format date strings**
