### PR TITLE
Format exception response

### DIFF
--- a/src/dapla_metadata/variable_definitions/exceptions.py
+++ b/src/dapla_metadata/variable_definitions/exceptions.py
@@ -39,10 +39,10 @@ class VardefClientException(OpenApiException):
             self.status = data.get("status", "Unknown status")
             if data.get("title") == "Constraint Violation":
                 violations = data.get("violations", [])
-                self.detail = [
-                    f"{violation.get('field', 'Unknown field')}: {violation.get('message', 'No message provided')}"
+                self.detail = "".join(
+                    f"\n{violation.get('field', 'Unknown field')}: {violation.get('message', 'No message provided')}"
                     for violation in violations
-                ]
+                )
 
             else:
                 self.detail = data.get("detail", "No detail provided")

--- a/src/dapla_metadata/variable_definitions/exceptions.py
+++ b/src/dapla_metadata/variable_definitions/exceptions.py
@@ -39,13 +39,16 @@ class VardefClientException(OpenApiException):
             self.status = data.get("status", "Unknown status")
             if data.get("title") == "Constraint Violation":
                 violations = data.get("violations", [])
-                self.detail = [
-                    {
-                        "field": violation.get("field", "Unknown field"),
-                        "message": violation.get("message", "No message provided"),
-                    }
-                    for violation in violations
-                ]
+                self.detail = json.dumps(
+                    [
+                        {
+                            "field": violation.get("field", "Unknown field"),
+                            "message": violation.get("message", "No message provided"),
+                        }
+                        for violation in violations
+                    ],
+                    indent=4,
+                )
             else:
                 self.detail = data.get("detail", "No detail provided")
             self.response_body = response_body

--- a/src/dapla_metadata/variable_definitions/exceptions.py
+++ b/src/dapla_metadata/variable_definitions/exceptions.py
@@ -39,16 +39,11 @@ class VardefClientException(OpenApiException):
             self.status = data.get("status", "Unknown status")
             if data.get("title") == "Constraint Violation":
                 violations = data.get("violations", [])
-                self.detail = json.dumps(
-                    [
-                        {
-                            "field": violation.get("field", "Unknown field"),
-                            "message": violation.get("message", "No message provided"),
-                        }
-                        for violation in violations
-                    ],
-                    indent=4,
-                )
+                self.detail = [
+                    f"{violation.get('field', 'Unknown field')}: {violation.get('message', 'No message provided')}"
+                    for violation in violations
+                ]
+
             else:
                 self.detail = data.get("detail", "No detail provided")
             self.response_body = response_body

--- a/src/dapla_metadata/variable_definitions/vardef.py
+++ b/src/dapla_metadata/variable_definitions/vardef.py
@@ -12,6 +12,9 @@ from dapla_metadata.variable_definitions.generated.vardef_client.api.draft_varia
 from dapla_metadata.variable_definitions.generated.vardef_client.api.variable_definitions_api import (
     VariableDefinitionsApi,
 )
+from dapla_metadata.variable_definitions.generated.vardef_client.models.contact import (
+    Contact,
+)
 from dapla_metadata.variable_definitions.generated.vardef_client.models.draft import (
     Draft,
 )
@@ -79,6 +82,7 @@ class Vardef:
     """
 
     @classmethod
+    @vardef_exception_handler
     def create_draft(cls, draft: Draft) -> VariableDefinition:
         """Create a Draft Variable Definition."""
         return VariableDefinition.from_complete_response(
@@ -169,3 +173,19 @@ class Vardef:
                 date_of_validity=date_of_validity,
             ),
         )
+
+    draft = Draft(
+        name={"nb": "testing"},
+        short_name="test",
+        definition={"nb": "def testing"},
+        classification_reference="91",
+        unit_types=["haha"],
+        subject_fields=["a"],
+        contains_sensitive_personal_information=True,
+        measurement_type="01",
+        valid_from=date(2024, 11, 1),
+        external_reference_uri="http://www.example.com",
+        comment=None,
+        related_variable_definition_uris=["http://www.example.com"],
+        contact=Contact(title={"nb": "title"}, email="cbi@ssb.no"),
+    )

--- a/src/dapla_metadata/variable_definitions/vardef.py
+++ b/src/dapla_metadata/variable_definitions/vardef.py
@@ -12,9 +12,6 @@ from dapla_metadata.variable_definitions.generated.vardef_client.api.draft_varia
 from dapla_metadata.variable_definitions.generated.vardef_client.api.variable_definitions_api import (
     VariableDefinitionsApi,
 )
-from dapla_metadata.variable_definitions.generated.vardef_client.models.contact import (
-    Contact,
-)
 from dapla_metadata.variable_definitions.generated.vardef_client.models.draft import (
     Draft,
 )
@@ -173,19 +170,3 @@ class Vardef:
                 date_of_validity=date_of_validity,
             ),
         )
-
-    draft = Draft(
-        name={"nb": "testing"},
-        short_name="test",
-        definition={"nb": "def testing"},
-        classification_reference="91",
-        unit_types=["haha"],
-        subject_fields=["a"],
-        contains_sensitive_personal_information=True,
-        measurement_type="01",
-        valid_from=date(2024, 11, 1),
-        external_reference_uri="http://www.example.com",
-        comment=None,
-        related_variable_definition_uris=["http://www.example.com"],
-        contact=Contact(title={"nb": "title"}, email="cbi@ssb.no"),
-    )

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -81,7 +81,6 @@ CONSTRAINT_VIOLATION_BODY_MISSING_FIELD = """{
             "message": "Invalid Dapla team"
         },
         {
-            "field": "updateVariableDefinitionById.updateDraft.owner.team",
             "message": "must not be empty"
         }
     ]

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -81,6 +81,7 @@ CONSTRAINT_VIOLATION_BODY_MISSING_FIELD = """{
             "message": "Invalid Dapla team"
         },
         {
+            "field": "updateVariableDefinitionById.updateDraft.owner.team",
             "message": "must not be empty"
         }
     ]

--- a/tests/variable_definitions/vardef_client/test_exceptions.py
+++ b/tests/variable_definitions/vardef_client/test_exceptions.py
@@ -50,9 +50,9 @@ def test_constraint_violation():
     response_body = CONSTRAINT_VIOLATION_BODY
     exc = VardefClientException(response_body)
     assert exc.status == BAD_REQUEST_STATUS
-    assert (
-        exc.detail[0]
-        == "updateVariableDefinitionById.updateDraft.owner.team: Invalid Dapla team"
+    assert exc.detail == (
+        "\nupdateVariableDefinitionById.updateDraft.owner.team: Invalid Dapla team"
+        "\nupdateVariableDefinitionById.updateDraft.owner.team: must not be empty"
     )
 
 
@@ -60,9 +60,9 @@ def test_constraint_violation_missing_messages():
     response_body = CONSTRAINT_VIOLATION_BODY_MISSING_MESSAGES
     exc = VardefClientException(response_body)
     assert exc.status == BAD_REQUEST_STATUS
-    assert (
-        exc.detail[0]
-        == "updateVariableDefinitionById.updateDraft.owner.team: No message provided"
+    assert exc.detail == (
+        "\nupdateVariableDefinitionById.updateDraft.owner.team: No message provided"
+        "\nupdateVariableDefinitionById.updateDraft.owner.team: No message provided"
     )
 
 
@@ -70,14 +70,13 @@ def test_constraint_violation_empty_violations():
     response_body = CONSTRAINT_VIOLATION_BODY_MISSING_VIOLATIONS
     exc = VardefClientException(response_body)
     assert exc.status == BAD_REQUEST_STATUS
-    assert str(exc) == "Status 400: []"
+    assert str(exc) == "Status 400: "
 
 
 def test_constraint_violation_empty_field():
     response_body = CONSTRAINT_VIOLATION_BODY_MISSING_FIELD
     exc = VardefClientException(response_body)
     assert exc.status == BAD_REQUEST_STATUS
-    assert exc.detail == [
-        "Unknown field: Invalid Dapla team",
-        "updateVariableDefinitionById.updateDraft.owner.team: must not be empty",
-    ]
+    assert exc.detail == (
+        "\nUnknown field: Invalid Dapla team\nUnknown field: must not be empty"
+    )

--- a/tests/variable_definitions/vardef_client/test_exceptions.py
+++ b/tests/variable_definitions/vardef_client/test_exceptions.py
@@ -60,7 +60,7 @@ def test_constraint_violation_missing_messages():
     response_body = CONSTRAINT_VIOLATION_BODY_MISSING_MESSAGES
     exc = VardefClientException(response_body)
     assert exc.status == BAD_REQUEST_STATUS
-    assert exc.detail[0]["message"] == "No message provided"
+    assert exc.detail[0] == "updateVariableDefinitionById.updateDraft.owner.team: No message provided"
 
 
 def test_constraint_violation_empty_violations():

--- a/tests/variable_definitions/vardef_client/test_exceptions.py
+++ b/tests/variable_definitions/vardef_client/test_exceptions.py
@@ -60,7 +60,10 @@ def test_constraint_violation_missing_messages():
     response_body = CONSTRAINT_VIOLATION_BODY_MISSING_MESSAGES
     exc = VardefClientException(response_body)
     assert exc.status == BAD_REQUEST_STATUS
-    assert exc.detail[0] == "updateVariableDefinitionById.updateDraft.owner.team: No message provided"
+    assert (
+        exc.detail[0]
+        == "updateVariableDefinitionById.updateDraft.owner.team: No message provided"
+    )
 
 
 def test_constraint_violation_empty_violations():

--- a/tests/variable_definitions/vardef_client/test_exceptions.py
+++ b/tests/variable_definitions/vardef_client/test_exceptions.py
@@ -1,7 +1,5 @@
 """Tests for Vardef client exception handling."""
 
-import json
-
 from dapla_metadata.variable_definitions.exceptions import VardefClientException
 from tests.utils.constants import BAD_REQUEST_STATUS
 from tests.utils.constants import CONSTRAINT_VIOLATION_BODY
@@ -52,11 +50,9 @@ def test_constraint_violation():
     response_body = CONSTRAINT_VIOLATION_BODY
     exc = VardefClientException(response_body)
     assert exc.status == BAD_REQUEST_STATUS
-    assert exc.detail[0]["message"] == "Invalid Dapla team"
     assert (
-        str(exc) == "Status 400: ["
-        "{'field': 'updateVariableDefinitionById.updateDraft.owner.team', 'message': 'Invalid Dapla team'}, "
-        "{'field': 'updateVariableDefinitionById.updateDraft.owner.team', 'message': 'must not be empty'}]"
+        exc.detail[0]
+        == "updateVariableDefinitionById.updateDraft.owner.team: Invalid Dapla team"
     )
 
 
@@ -78,17 +74,7 @@ def test_constraint_violation_empty_field():
     response_body = CONSTRAINT_VIOLATION_BODY_MISSING_FIELD
     exc = VardefClientException(response_body)
     assert exc.status == BAD_REQUEST_STATUS
-    excpected_message = json.dumps(
-        [
-            {
-                "field": "Unknown field",
-                "message": "Invalid Dapla team",
-            },
-            {
-                "field": "Unknown field",
-                "message": "must not be empty",
-            },
-        ],
-        indent=4,
-    )
-    assert exc.detail == excpected_message
+    assert exc.detail == [
+        "Unknown field: Invalid Dapla team",
+        "updateVariableDefinitionById.updateDraft.owner.team: must not be empty",
+    ]

--- a/tests/variable_definitions/vardef_client/test_exceptions.py
+++ b/tests/variable_definitions/vardef_client/test_exceptions.py
@@ -1,5 +1,7 @@
 """Tests for Vardef client exception handling."""
 
+import json
+
 from dapla_metadata.variable_definitions.exceptions import VardefClientException
 from tests.utils.constants import BAD_REQUEST_STATUS
 from tests.utils.constants import CONSTRAINT_VIOLATION_BODY
@@ -76,8 +78,17 @@ def test_constraint_violation_empty_field():
     response_body = CONSTRAINT_VIOLATION_BODY_MISSING_FIELD
     exc = VardefClientException(response_body)
     assert exc.status == BAD_REQUEST_STATUS
-    assert str(exc) == (
-        "Status 400: ["
-        "{'field': 'Unknown field', 'message': 'Invalid Dapla team'}, "
-        "{'field': 'Unknown field', 'message': 'must not be empty'}]"
+    excpected_message = json.dumps(
+        [
+            {
+                "field": "Unknown field",
+                "message": "Invalid Dapla team",
+            },
+            {
+                "field": "Unknown field",
+                "message": "must not be empty",
+            },
+        ],
+        indent=4,
     )
+    assert exc.detail == excpected_message


### PR DESCRIPTION
- Format list of violations as string separated by new line for each violation
- User who needs to access the original response format can use "response_body"

