### PR TITLE
Response models print as indented JSON

### DIFF
--- a/src/dapla_metadata/variable_definitions/__init__.py
+++ b/src/dapla_metadata/variable_definitions/__init__.py
@@ -1,4 +1,7 @@
 """Client for working with Variable Definitions at Statistics Norway."""
 
+from .generated.vardef_client.exceptions import *  # noqa: F403
+from .generated.vardef_client.models import *  # noqa: F403
 from .vardef import Vardef
+from .variable_definition import CompletePatchOutput
 from .variable_definition import VariableDefinition

--- a/src/dapla_metadata/variable_definitions/vardef.py
+++ b/src/dapla_metadata/variable_definitions/vardef.py
@@ -82,7 +82,7 @@ class Vardef:
     @vardef_exception_handler
     def create_draft(cls, draft: Draft) -> VariableDefinition:
         """Create a Draft Variable Definition."""
-        return VariableDefinition.from_complete_response(
+        return VariableDefinition.from_model(
             DraftVariableDefinitionsApi(
                 VardefClient.get_client(),
             ).create_variable_definition(
@@ -105,7 +105,7 @@ class Vardef:
         Returns:
             VariableDefinition: The migrated Variable Definition in Vardef.
         """
-        return VariableDefinition.from_complete_response(
+        return VariableDefinition.from_model(
             DataMigrationApi(
                 VardefClient.get_client(),
             ).create_variable_definition_from_var_dok(
@@ -135,7 +135,7 @@ class Vardef:
             list[VariableDefinition]: The list of Variable Definitions.
         """
         return [
-            VariableDefinition.from_complete_response(definition)
+            VariableDefinition.from_model(definition)
             for definition in VariableDefinitionsApi(
                 VardefClient.get_client(),
             ).list_variable_definitions(
@@ -162,7 +162,7 @@ class Vardef:
         Raises:
             NotFoundException when the given ID is not found
         """
-        return VariableDefinition.from_complete_response(
+        return VariableDefinition.from_model(
             VariableDefinitionsApi(
                 VardefClient.get_client(),
             ).get_variable_definition_by_id(

--- a/src/dapla_metadata/variable_definitions/variable_definition.py
+++ b/src/dapla_metadata/variable_definitions/variable_definition.py
@@ -33,7 +33,7 @@ class CompletePatchOutput(CompleteResponse):
     def from_model(
         model: CompleteResponse,
     ) -> "CompletePatchOutput":
-        """Create a CompletePatchOutput instance from a CompleteResponse."""
+        """Create a CompletePatchOutput instance from a CompletePatchOutput."""
         return CompletePatchOutput.model_construct(**model.model_dump())
 
     def __str__(self) -> str:
@@ -56,11 +56,11 @@ class VariableDefinition(CompletePatchOutput):
     def from_model(
         model: CompleteResponse,
     ) -> "VariableDefinition":
-        """Create a VariableDefinition instance from a CompleteResponse or CompletePatchOutput."""
+        """Create a VariableDefinition instance from a CompletePatchOutput or CompletePatchOutput."""
         return VariableDefinition.model_construct(**model.model_dump())
 
     @vardef_exception_handler
-    def list_validity_periods(self) -> list[CompleteResponse]:
+    def list_validity_periods(self) -> list[CompletePatchOutput]:
         """List all Validity Periods for this Variable Definition."""
         return [
             CompletePatchOutput.from_model(validity_period)
@@ -72,7 +72,7 @@ class VariableDefinition(CompletePatchOutput):
         ]
 
     @vardef_exception_handler
-    def list_patches(self) -> list[CompleteResponse]:
+    def list_patches(self) -> list[CompletePatchOutput]:
         """List all Patches for this Variable Definition."""
         return [
             CompletePatchOutput.from_model(patch)
@@ -85,7 +85,7 @@ class VariableDefinition(CompletePatchOutput):
     def update_draft(
         self,
         update_draft: UpdateDraft,
-    ) -> CompleteResponse:
+    ) -> CompletePatchOutput:
         """Update this Variable definition.
 
         Variable definition must have status 'DRAFT'.
@@ -94,14 +94,16 @@ class VariableDefinition(CompletePatchOutput):
             update_draft: The input with updated values.
 
         Returns:
-            CompleteResponse: Updated Variable definition with all details.
+            CompletePatchOutput: Updated Variable definition with all details.
         """
-        return DraftVariableDefinitionsApi(
-            VardefClient.get_client(),
-        ).update_variable_definition_by_id(
-            variable_definition_id=self.id,
-            active_group=config.get_active_group(),
-            update_draft=update_draft,
+        return CompletePatchOutput.from_model(
+            DraftVariableDefinitionsApi(
+                VardefClient.get_client(),
+            ).update_variable_definition_by_id(
+                variable_definition_id=self.id,
+                active_group=config.get_active_group(),
+                update_draft=update_draft,
+            ),
         )
 
     @vardef_exception_handler
@@ -125,7 +127,7 @@ class VariableDefinition(CompletePatchOutput):
         return f"Variable {self.id} safely deleted"
 
     @vardef_exception_handler
-    def get_patch(self, patch_id: int) -> CompleteResponse:
+    def get_patch(self, patch_id: int) -> CompletePatchOutput:
         """Get a single Patch by ID.
 
         Args:
@@ -146,7 +148,7 @@ class VariableDefinition(CompletePatchOutput):
         self,
         patch: Patch,
         valid_from: date | None = None,
-    ) -> CompleteResponse:
+    ) -> CompletePatchOutput:
         """Create a new patch for this Variable definition.
 
         Args:
@@ -155,23 +157,25 @@ class VariableDefinition(CompletePatchOutput):
             If value is None the patch is created in the last validity period.
 
         Returns:
-            CompleteResponse: Variable definition with all details.
+            CompletePatchOutput: Variable definition with all details.
 
         """
-        return PatchesApi(
-            VardefClient.get_client(),
-        ).create_patch(
-            variable_definition_id=self.id,
-            active_group=config.get_active_group(),
-            patch=patch,
-            valid_from=valid_from,
+        return CompletePatchOutput.from_model(
+            PatchesApi(
+                VardefClient.get_client(),
+            ).create_patch(
+                variable_definition_id=self.id,
+                active_group=config.get_active_group(),
+                patch=patch,
+                valid_from=valid_from,
+            ),
         )
 
     @vardef_exception_handler
     def create_validity_period(
         self,
         validity_period: ValidityPeriod,
-    ) -> CompleteResponse:
+    ) -> CompletePatchOutput:
         """Create a new validity period for this Variable definition.
 
         In order to create a new validity period input must contain updated
@@ -181,12 +185,14 @@ class VariableDefinition(CompletePatchOutput):
             validity_period: The input for new validity period
 
         Returns:
-            CompleteResponse: Variable definition with all details.
+            CompletePatchOutput: Variable definition with all details.
         """
-        return ValidityPeriodsApi(
-            VardefClient.get_client(),
-        ).create_validity_period(
-            variable_definition_id=self.id,
-            active_group=config.get_active_group(),
-            validity_period=validity_period,
+        return CompletePatchOutput.from_model(
+            ValidityPeriodsApi(
+                VardefClient.get_client(),
+            ).create_validity_period(
+                variable_definition_id=self.id,
+                active_group=config.get_active_group(),
+                validity_period=validity_period,
+            ),
         )

--- a/src/dapla_metadata/variable_definitions/variable_definition.py
+++ b/src/dapla_metadata/variable_definitions/variable_definition.py
@@ -10,7 +10,22 @@ from dapla_metadata.variable_definitions.generated.vardef_client.models.complete
 )
 
 
-class VariableDefinition(CompleteResponse):
+class CompletePatchOutput(CompleteResponse):
+    """Complete response For internal users who need all details while maintaining variable definitions."""
+
+    @staticmethod
+    def from_model(
+        model: CompleteResponse,
+    ) -> "CompletePatchOutput":
+        """Create a CompletePatchOutput instance from a CompleteResponse."""
+        return CompletePatchOutput.model_construct(**model.model_dump())
+
+    def __str__(self) -> str:
+        """Format as indented JSON."""
+        return self.model_dump_json(indent=2)
+
+
+class VariableDefinition(CompletePatchOutput):
     """A Variable Definition.
 
     - Provides access to the fields of the specific Variable Definition.
@@ -18,38 +33,48 @@ class VariableDefinition(CompleteResponse):
     - Provides methods allowing maintenance of this Variable Definition.
 
     Args:
-        CompleteResponse: The Pydantic model superclass, representing a Variable Definition.
+        CompletePatchOutput: The Pydantic model superclass, representing a Variable Definition.
     """
 
     @staticmethod
-    def from_complete_response(
-        complete_response: CompleteResponse,
+    def from_model(
+        model: CompleteResponse,
     ) -> "VariableDefinition":
-        """Create a VariableDefinition instance from a CompleteResponse."""
-        return VariableDefinition.model_construct(**complete_response.model_dump())
+        """Create a VariableDefinition instance from a CompleteResponse or CompletePatchOutput."""
+        return VariableDefinition.model_construct(**model.model_dump())
 
-    def list_validity_periods(self) -> list[CompleteResponse]:
+    def list_validity_periods(self) -> list[CompletePatchOutput]:
         """List all Validity Periods for this Variable Definition."""
-        return ValidityPeriodsApi(VardefClient.get_client()).list_validity_periods(
-            variable_definition_id=self.id,
-        )
+        return [
+            CompletePatchOutput.from_model(validity_period)
+            for validity_period in ValidityPeriodsApi(
+                VardefClient.get_client(),
+            ).list_validity_periods(
+                variable_definition_id=self.id,
+            )
+        ]
 
-    def list_patches(self) -> list[CompleteResponse]:
+    def list_patches(self) -> list[CompletePatchOutput]:
         """List all Patches for this Variable Definition."""
-        return PatchesApi(VardefClient.get_client()).list_patches(
-            variable_definition_id=self.id,
-        )
+        return [
+            CompletePatchOutput.from_model(patch)
+            for patch in PatchesApi(VardefClient.get_client()).list_patches(
+                variable_definition_id=self.id,
+            )
+        ]
 
-    def get_patch(self, patch_id: int) -> CompleteResponse:
+    def get_patch(self, patch_id: int) -> CompletePatchOutput:
         """Get a single Patch by ID.
 
         Args:
             patch_id (int): The ID of the patch.
 
         Returns:
-            CompleteResponse: The desired patch.
+            CompletePatchOutput: The desired patch.
         """
-        return PatchesApi(VardefClient.get_client()).get_patch(
-            variable_definition_id=self.id,
-            patch_id=patch_id,
+        return CompletePatchOutput.from_model(
+            PatchesApi(VardefClient.get_client()).get_patch(
+                variable_definition_id=self.id,
+                patch_id=patch_id,
+            ),
         )

--- a/tests/variable_definitions/test_vardef.py
+++ b/tests/variable_definitions/test_vardef.py
@@ -9,9 +9,6 @@ from dapla_metadata.variable_definitions.generated.vardef_client.configuration i
 from dapla_metadata.variable_definitions.generated.vardef_client.models.complete_response import (
     CompletePatchOutput,
 )
-from dapla_metadata.variable_definitions.generated.vardef_client.models.complete_response import (
-    CompleteResponse,
-)
 from dapla_metadata.variable_definitions.generated.vardef_client.models.draft import (
     Draft,
 )
@@ -137,7 +134,7 @@ def test_update_draft(
     my_draft = Vardef.get_variable_definition(
         variable_definition_id=VARDEF_EXAMPLE_DEFINITION_ID,
     )
-    assert isinstance(my_draft.update_draft(update_draft), CompleteResponse)
+    assert isinstance(my_draft.update_draft(update_draft), CompletePatchOutput)
 
 
 def test_delete_draft(
@@ -170,7 +167,7 @@ def test_create_patch(
     )
     assert isinstance(
         created_patch,
-        CompleteResponse,
+        CompletePatchOutput,
     )
     assert created_patch.patch_id == PATCH_ID
 
@@ -186,5 +183,5 @@ def test_create_validity_period(
     my_variable = variable_definition
     assert isinstance(
         my_variable.create_validity_period(validity_period),
-        CompleteResponse,
+        CompletePatchOutput,
     )

--- a/tests/variable_definitions/test_vardef.py
+++ b/tests/variable_definitions/test_vardef.py
@@ -6,9 +6,6 @@ from dapla_metadata.variable_definitions.exceptions import VardefClientException
 from dapla_metadata.variable_definitions.generated.vardef_client.configuration import (
     Configuration,
 )
-from dapla_metadata.variable_definitions.generated.vardef_client.models.complete_response import (
-    CompletePatchOutput,
-)
 from dapla_metadata.variable_definitions.generated.vardef_client.models.draft import (
     Draft,
 )
@@ -25,6 +22,7 @@ from dapla_metadata.variable_definitions.generated.vardef_client.models.variable
     VariableStatus,
 )
 from dapla_metadata.variable_definitions.vardef import Vardef
+from dapla_metadata.variable_definitions.variable_definition import CompletePatchOutput
 from dapla_metadata.variable_definitions.variable_definition import VariableDefinition
 from tests.utils.constants import NOT_FOUND_STATUS
 from tests.utils.constants import VARDEF_EXAMPLE_ACTIVE_GROUP

--- a/tests/variable_definitions/test_vardef.py
+++ b/tests/variable_definitions/test_vardef.py
@@ -7,7 +7,7 @@ from dapla_metadata.variable_definitions.generated.vardef_client.configuration i
     Configuration,
 )
 from dapla_metadata.variable_definitions.generated.vardef_client.models.complete_response import (
-    CompleteResponse,
+    CompletePatchOutput,
 )
 from dapla_metadata.variable_definitions.generated.vardef_client.models.draft import (
     Draft,
@@ -34,7 +34,7 @@ def test_list_variable_definitions_with_date_of_validity(
     VardefClient.set_config(client_configuration)
     assert isinstance(
         Vardef.list_variable_definitions(date_of_validity=VARDEF_EXAMPLE_DATE)[0],
-        CompleteResponse,
+        CompletePatchOutput,
     )
 
 
@@ -63,7 +63,7 @@ def test_list_patches(client_configuration: Configuration):
     landbak = Vardef.get_variable_definition(
         variable_definition_id=VARDEF_EXAMPLE_DEFINITION_ID,
     )
-    assert isinstance(landbak.list_patches()[0], CompleteResponse)
+    assert isinstance(landbak.list_patches()[0], CompletePatchOutput)
 
 
 def test_get_patch(client_configuration: Configuration):
@@ -71,7 +71,7 @@ def test_get_patch(client_configuration: Configuration):
     landbak = Vardef.get_variable_definition(
         variable_definition_id=VARDEF_EXAMPLE_DEFINITION_ID,
     )
-    assert isinstance(landbak.get_patch(1), CompleteResponse)
+    assert isinstance(landbak.get_patch(1), CompletePatchOutput)
 
 
 def test_list_validity_periods(client_configuration: Configuration):
@@ -79,7 +79,7 @@ def test_list_validity_periods(client_configuration: Configuration):
     landbak = Vardef.get_variable_definition(
         variable_definition_id=VARDEF_EXAMPLE_DEFINITION_ID,
     )
-    assert isinstance(landbak.list_validity_periods()[0], CompleteResponse)
+    assert isinstance(landbak.list_validity_periods()[0], CompletePatchOutput)
 
 
 def test_create_draft(
@@ -92,7 +92,7 @@ def test_create_draft(
     my_draft = Vardef.create_draft(
         draft=draft,
     )
-    assert isinstance(my_draft, CompleteResponse)
+    assert isinstance(my_draft, CompletePatchOutput)
     assert my_draft.id is not None
     assert my_draft.patch_id == 1
     assert my_draft.variable_status == VariableStatus.DRAFT
@@ -107,7 +107,7 @@ def test_migrate_from_vardok(
     my_draft = Vardef.migrate_from_vardok(
         vardok_id="1607",
     )
-    assert isinstance(my_draft, CompleteResponse)
+    assert isinstance(my_draft, CompletePatchOutput)
     assert my_draft.id is not None
     assert my_draft.patch_id == 1
     assert my_draft.variable_status == VariableStatus.DRAFT

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -1,0 +1,101 @@
+from datetime import date
+
+from dapla_metadata.variable_definitions.generated.vardef_client.models.person import (
+    Person,
+)
+from dapla_metadata.variable_definitions.generated.vardef_client.models.variable_status import (
+    VariableStatus,
+)
+from dapla_metadata.variable_definitions.variable_definition import VariableDefinition
+from tests.utils.constants import VARDEF_EXAMPLE_DEFINITION_ID
+
+
+def test_str(language_string_type, contact, owner):
+    variable_definition = VariableDefinition(
+        id=VARDEF_EXAMPLE_DEFINITION_ID,
+        patch_id=1,
+        name=language_string_type,
+        short_name="var_test",
+        definition=language_string_type,
+        classification_reference="91",
+        unit_types=["01"],
+        subject_fields=["a", "b"],
+        contains_special_categories_of_personal_data=True,
+        variable_status=VariableStatus.PUBLISHED_EXTERNAL,
+        measurement_type="test",
+        valid_from=date(2024, 11, 1),
+        valid_until=None,
+        external_reference_uri="http://www.example.com",
+        comment=language_string_type,
+        related_variable_definition_uris=["http://www.example.com"],
+        contact=contact,
+        owner=owner,
+        created_at=date(2024, 11, 1),
+        created_by=Person(code="724", name="name"),
+        last_updated_at=date(2024, 11, 1),
+        last_updated_by=Person(code="724", name="name"),
+    )
+    assert (
+        str(variable_definition)
+        == """{
+  "id": "wypvb3wd",
+  "patch_id": 1,
+  "name": {
+    "nb": "test",
+    "nn": "test",
+    "en": "test"
+  },
+  "short_name": "var_test",
+  "definition": {
+    "nb": "test",
+    "nn": "test",
+    "en": "test"
+  },
+  "classification_reference": "91",
+  "unit_types": [
+    "01"
+  ],
+  "subject_fields": [
+    "a",
+    "b"
+  ],
+  "contains_special_categories_of_personal_data": true,
+  "variable_status": "PUBLISHED_EXTERNAL",
+  "measurement_type": "test",
+  "valid_from": "2024-11-01",
+  "valid_until": null,
+  "external_reference_uri": "http://www.example.com",
+  "comment": {
+    "nb": "test",
+    "nn": "test",
+    "en": "test"
+  },
+  "related_variable_definition_uris": [
+    "http://www.example.com"
+  ],
+  "owner": {
+    "team": "my_team",
+    "groups": [
+      "my_team_developers"
+    ]
+  },
+  "contact": {
+    "title": {
+      "nb": "test",
+      "nn": "test",
+      "en": "test"
+    },
+    "email": "me@example.com"
+  },
+  "created_at": "2024-11-01T00:00:00",
+  "created_by": {
+    "code": "724",
+    "name": "name"
+  },
+  "last_updated_at": "2024-11-01T00:00:00",
+  "last_updated_by": {
+    "code": "724",
+    "name": "name"
+  }
+}"""
+    )

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -1,40 +1,4 @@
-from datetime import date
-
-from dapla_metadata.variable_definitions.generated.vardef_client.models.person import (
-    Person,
-)
-from dapla_metadata.variable_definitions.generated.vardef_client.models.variable_status import (
-    VariableStatus,
-)
-from dapla_metadata.variable_definitions.variable_definition import VariableDefinition
-from tests.utils.constants import VARDEF_EXAMPLE_DEFINITION_ID
-
-
-def test_str(language_string_type, contact, owner):
-    variable_definition = VariableDefinition(
-        id=VARDEF_EXAMPLE_DEFINITION_ID,
-        patch_id=1,
-        name=language_string_type,
-        short_name="var_test",
-        definition=language_string_type,
-        classification_reference="91",
-        unit_types=["01"],
-        subject_fields=["a", "b"],
-        contains_special_categories_of_personal_data=True,
-        variable_status=VariableStatus.PUBLISHED_EXTERNAL,
-        measurement_type="test",
-        valid_from=date(2024, 11, 1),
-        valid_until=None,
-        external_reference_uri="http://www.example.com",
-        comment=language_string_type,
-        related_variable_definition_uris=["http://www.example.com"],
-        contact=contact,
-        owner=owner,
-        created_at=date(2024, 11, 1),
-        created_by=Person(code="724", name="name"),
-        last_updated_at=date(2024, 11, 1),
-        last_updated_by=Person(code="724", name="name"),
-    )
+def test_str(variable_definition):
     assert (
         str(variable_definition)
         == """{


### PR DESCRIPTION
### Summary

This overrides the python ["dunder method" `__str__`](https://docs.python.org/3/reference/datamodel.html#object.__str__) to provide a much more readable representation of a Variable Definition.

### Before

```
id='wypvb3wd' patch_id=1 name=LanguageStringType(nb='Landbakgrunn', nn='Landbakgrunn', en='Country Background') short_name='landbak' definition=LanguageStringType(nb='For personer født i utlandet, er dette (med noen få unntak) eget fødeland. For personer født i Norge er det foreldrenes fødeland. I de tilfeller der foreldrene har ulikt fødeland, er det morens fødeland som blir valgt. Hvis ikke personen selv eller noen av foreldrene er utenlandsfødt, hentes landbakgrunn fra de første utenlandsfødte en treffer på i rekkefølgen mormor, morfar, farmor eller farfar.', nn='For personar fødd i utlandet, er dette (med nokre få unntak) eige fødeland. For personar fødd i Noreg er det fødelandet til foreldra. I dei tilfella der foreldra har ulikt fødeland, er det fødelandet til mora som blir valt. Viss ikkje personen sjølv eller nokon av foreldra er utenlandsfødt, blir henta landsbakgrunn frå dei første utenlandsfødte ein treffar på i rekkjefølgja mormor, morfar, farmor eller farfar.', en="Country background is the person's own, the mother's or possibly the father's country of birth. Persons without an immigrant background always have Norway as country background. In cases where the parents have different countries of birth the mother's country of birth is chosen. If neither the person nor the parents are born abroad, country background is chosen from the first person born abroad in the order mother's mother, mother's father, father's mother, father's father.") classification_reference='91' unit_types=['01', '02'] subject_fields=['he04'] contains_special_categories_of_personal_data=True variable_status=<VariableStatus.DRAFT: 'DRAFT'> measurement_type=None valid_from=datetime.date(2003, 1, 1) valid_until=None external_reference_uri='https://www.ssb.no/a/metadata/conceptvariable/vardok/1919/nb' comment=LanguageStringType(nb='Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland.', nn='Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland.', en="As of 1 January 2003, the definition was changed to also include the grandparents' country of birth.") related_variable_definition_uris=['https://example.com/'] owner=Owner(team='team-a', groups=['team-a-developers']) contact=Contact(title=LanguageStringType(nb='Seksjon for befolkningsstatistikk', nn='Seksjon for befolkningsstatistikk', en='Division for population statistics'), email='s320@ssb.no') created_at=datetime.datetime(2024, 6, 11, 8, 15, 19, 38000, tzinfo=TzInfo(UTC)) created_by=Person(code='ano@ssb.no', name='Ola Nordmann') last_updated_at=datetime.datetime(2024, 6, 11, 8, 15, 19, 38000, tzinfo=TzInfo(UTC)) last_updated_by=Person(code='ano@ssb.no', name='Ola Nordmann')
```

### After

```
{
  "id": "wypvb3wd",
  "patch_id": 1,
  "name": {
    "nb": "test",
    "nn": "test",
    "en": "test"
  },
  "short_name": "var_test",
  "definition": {
    "nb": "test",
    "nn": "test",
    "en": "test"
  },
  "classification_reference": "91",
  "unit_types": [
    "01"
  ],
  "subject_fields": [
    "a",
    "b"
  ],
  "contains_special_categories_of_personal_data": true,
  "variable_status": "PUBLISHED_EXTERNAL",
  "measurement_type": "test",
  "valid_from": "2024-11-01",
  "valid_until": null,
  "external_reference_uri": "http://www.example.com",
  "comment": {
    "nb": "test",
    "nn": "test",
    "en": "test"
  },
  "related_variable_definition_uris": [
    "http://www.example.com"
  ],
  "owner": {
    "team": "my_team",
    "groups": [
      "my_team_developers"
    ]
  },
  "contact": {
    "title": {
      "nb": "test",
      "nn": "test",
      "en": "test"
    },
    "email": "me@example.com"
  },
  "created_at": "2024-11-01T00:00:00",
  "created_by": {
    "code": "724",
    "name": "name"
  },
  "last_updated_at": "2024-11-01T00:00:00",
  "last_updated_by": {
    "code": "724",
    "name": "name"
  }
}
```
