### PR TITLE
set warnings to false

### DIFF
--- a/src/dapla_metadata/variable_definitions/variable_definition.py
+++ b/src/dapla_metadata/variable_definitions/variable_definition.py
@@ -38,7 +38,7 @@ class CompletePatchOutput(CompleteResponse):
 
     def __str__(self) -> str:
         """Format as indented JSON."""
-        return self.model_dump_json(indent=2)
+        return self.model_dump_json(indent=2, warnings=False)
 
 
 class VariableDefinition(CompletePatchOutput):


### PR DESCRIPTION
For a cleaner print we don't want to print warnings irrelevant for user workflow:

<img width="1135" alt="Screenshot 2024-12-18 at 21 22 11" src="https://github.com/user-attachments/assets/2fb3075a-3460-41cd-8003-2010bbd47ab4" />

Set "warnings=False":

<img width="516" alt="Screenshot 2024-12-18 at 21 23 15" src="https://github.com/user-attachments/assets/98411087-a1f3-4ace-9176-2128d20b4053" />
