### PR TITLE
Update sonar cloud job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,10 +165,10 @@ jobs:
           sed -i "s/<source><\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
           sed -i "s/<source>tests/<source>\/github\/workspace\/tests/g" coverage.xml
 
-      - name: SonarCloud Scan
+      - name: SonarQube Scan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         # No need to run SonarCloud analysis if dependabot update or token not defined
         if: env.SONAR_TOKEN != '' && (github.actor != 'dependabot[bot]')
-        uses: SonarSource/sonarcloud-github-action@v4.0.0
+        uses: SonarSource/sonarqube-scan-action@v4


### PR DESCRIPTION
Github actions job for Sonar cloud seems to be deprecated now

ref: https://github.com/SonarSource/sonarcloud-github-action
ref: https://docs.sonarsource.com/sonarqube-cloud/enriching/test-coverage/python-test-coverage/


