### PR TITLE
Simplify imports in vardef demo notebook

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
     ],
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
-    "ruff.lint.run": "onType"
+    "ruff.lint.run": "onType",
+    "makefile.configureOnOpen": false
 }

--- a/demo/variable_definitions/vardef_demo.ipynb
+++ b/demo/variable_definitions/vardef_demo.ipynb
@@ -32,22 +32,8 @@
     "from datetime import date\n",
     "from pprint import pprint\n",
     "\n",
-    "from dapla_metadata.variable_definitions.generated.vardef_client.models.contact import (\n",
-    "    Contact,\n",
-    ")\n",
-    "from dapla_metadata.variable_definitions.generated.vardef_client.models.draft import (\n",
-    "    Draft,\n",
-    ")\n",
-    "from dapla_metadata.variable_definitions.generated.vardef_client.models.update_draft import (\n",
-    "    UpdateDraft,\n",
-    ")\n",
-    "from dapla_metadata.variable_definitions.generated.vardef_client.models.validity_period import (\n",
-    "    ValidityPeriod,\n",
-    ")\n",
-    "from dapla_metadata.variable_definitions.generated.vardef_client.models.variable_status import (\n",
-    "    VariableStatus,\n",
-    ")\n",
-    "from dapla_metadata.variable_definitions.vardef import Vardef\n"
+    "from dapla_metadata.variable_definitions import Vardef\n",
+    "from dapla_metadata.variable_definitions import models\n"
    ]
   },
   {
@@ -81,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "draft = Draft(\n",
+    "draft = models.Draft(\n",
     "    name = {\n",
     "        \"nb\": \"test navn\",\n",
     "        \"nn\": \"test namn\",\n",
@@ -124,7 +110,7 @@
     "\n",
     "Vardef-modulen er designet for å hjelpe brukeren med å forvalte variabeldefinisjoner og kvalitetsikre at alle variabeldefinisjoner oppfyller nødvendige krav og regler.\n",
     "\n",
-    "I mange tilfeller blir `VardefClientException` returnert til brukeren med en tydelig feilmelding. Meldingen vil komme på bunnen av `tracestack`.\n",
+    "I mange tilfeller blir `VardefClientException` returnert til brukeren med en tydelig feilmelding. Meldingen vil komme på bunnen av `Traceback`.\n",
     "\n",
     "Det er nyttig å gjøre seg kjent med de ulike feilmeldingene da de gir viktig informasjon om hva som har gått galt og hvor feilen ligger. \n",
     "\n",
@@ -137,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "invalid_draft = Draft(\n",
+    "invalid_draft = models.Draft(\n",
     "    name = {\n",
     "        \"nb\": \"test navn\",\n",
     "        \"nn\": \"test namn\",\n",
@@ -219,7 +205,7 @@
    "outputs": [],
    "source": [
     "# Oppdater kontaktinformasjon\n",
-    "my_contact = Contact(\n",
+    "my_contact = models.Contact(\n",
     "    title={\n",
     "        \"nb\": \"Seksjon for befolkningsstatistikk\",\n",
     "        \"nn\": \"Seksjon for befolkningsstatistikk\",\n",
@@ -227,7 +213,7 @@
     "    },\n",
     "    email=\"sibby@ssb.no\",\n",
     ")\n",
-    "update_contact = UpdateDraft(\n",
+    "update_contact = models.UpdateDraft(\n",
     "    contact=my_contact,\n",
     ")\n",
     "\n",
@@ -252,7 +238,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "invalid_short_name = UpdateDraft(\n",
+    "invalid_short_name = models.UpdateDraft(\n",
     "    short_name=\"_)(45)\",\n",
     ")\n",
     "my_draft.update_draft(invalid_short_name)\n"
@@ -378,7 +364,7 @@
     "\n",
     "For eksempel: \n",
     "\n",
-    "> VariableStatus.PUBLISHED_INTERNAL \n",
+    "> models.VariableStatus.PUBLISHED_INTERNAL \n",
     "\n",
     "Merk at denne prosessen er irreversibel.\n",
     "\n",
@@ -392,8 +378,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "update_status = UpdateDraft(\n",
-    "    variable_status=VariableStatus.PUBLISHED_INTERNAL,\n",
+    "update_status = models.UpdateDraft(\n",
+    "    variable_status=models.VariableStatus.PUBLISHED_INTERNAL,\n",
     ")\n",
     "\n",
     "my_draft.update_draft(update_status)"
@@ -471,7 +457,7 @@
    "outputs": [],
    "source": [
     "# Opprette en nytt utkast for å demonstrere overføring av eierskap\n",
-    "owner_draft = Draft(\n",
+    "owner_draft = models.Draft(\n",
     "    name = {\n",
     "        \"nb\": \"test navn\",\n",
     "        \"nn\": \"test namn\",\n",
@@ -501,7 +487,7 @@
     "\n",
     "transfer_owner_draft = Vardef.create_draft(owner_draft)\n",
     "\n",
-    "transfer_owner_draft.update_draft(UpdateDraft(variable_status=VariableStatus.PUBLISHED_INTERNAL))\n",
+    "transfer_owner_draft.update_draft(models.UpdateDraft(variable_status=models.VariableStatus.PUBLISHED_INTERNAL))\n",
     "\n",
     "replace_owner = Patch(\n",
     "    owner=Owner(\n",
@@ -592,7 +578,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "valid_validity_period = ValidityPeriod(\n",
+    "valid_validity_period = models.ValidityPeriod(\n",
     "    definition={\n",
     "        \"nb\": \"ny definisjon2\",\n",
     "        \"nn\": \"ny definisjon2\",\n",
@@ -617,7 +603,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "invalid_validity_period = ValidityPeriod(\n",
+    "invalid_validity_period = models.ValidityPeriod(\n",
     "    name={\n",
     "        \"nb\": \"nytt navn\",\n",
     "    },\n",
@@ -727,11 +713,11 @@
     "\n",
     "\n",
     "print(\"\\nFiltrer etter status `DRAFT`: \")\n",
-    "draft_variables = [variable for variable in variable_definitions if variable.variable_status == VariableStatus.DRAFT]\n",
+    "draft_variables = [variable for variable in variable_definitions if variable.variable_status == models.VariableStatus.DRAFT]\n",
     "print(draft_variables)\n",
     "\n",
     "print(\"\\nFiltrer etter status `PUBLISHED INTERNAL`: \")\n",
-    "published_intern_variables = [variable for variable in variable_definitions if variable.variable_status == VariableStatus.PUBLISHED_INTERNAL]\n",
+    "published_intern_variables = [variable for variable in variable_definitions if variable.variable_status == models.VariableStatus.PUBLISHED_INTERNAL]\n",
     "print(published_intern_variables)\n"
    ]
   },
@@ -829,7 +815,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dapla-toolbelt-metadata-fJc960va-py3.12",
+   "display_name": "dapla-toolbelt-metadata-9NhZ1fWH-py3.12",
    "language": "python",
    "name": "python3"
   },
@@ -843,7 +829,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/src/dapla_metadata/variable_definitions/__init__.py
+++ b/src/dapla_metadata/variable_definitions/__init__.py
@@ -1,7 +1,7 @@
 """Client for working with Variable Definitions at Statistics Norway."""
 
+from .generated.vardef_client import models
 from .generated.vardef_client.exceptions import *  # noqa: F403
-from .generated.vardef_client.models import *  # noqa: F403
 from .vardef import Vardef
 from .variable_definition import CompletePatchOutput
 from .variable_definition import VariableDefinition


### PR DESCRIPTION
The import statements in the demo notebook are now simplified to be as shown below.

![Screenshot 2025-01-21 at 15 04 05](https://github.com/user-attachments/assets/8d652353-ec0d-49cc-87d1-283b9601931c)

Models may then be accessed as shown here:

![Screenshot 2025-01-21 at 15 04 18](https://github.com/user-attachments/assets/74da2626-1460-4cf5-90ab-66660cacc4a8)
