### PR TITLE
Read workspace dir from config

### DIFF
--- a/src/dapla_metadata/variable_definitions/config.py
+++ b/src/dapla_metadata/variable_definitions/config.py
@@ -27,7 +27,7 @@ def get_descriptions_path() -> str:
     )
 
 
-def get_workspace_dir() -> str:
+def get_workspace_dir() -> str | None:
     """Get the path to work directory from workspace environment variable."""
     return get_config_item("WORKSPACE_DIR")
 

--- a/src/dapla_metadata/variable_definitions/config.py
+++ b/src/dapla_metadata/variable_definitions/config.py
@@ -8,6 +8,9 @@ from dapla_metadata.variable_definitions.generated.vardef_client.configuration i
 )
 
 VARDEF_HOST_TEST = "https://metadata.intern.test.ssb.no"
+WORKSPACE_DIR = "WORKSPACE_DIR"
+VARDEF_DESCRIPTIONS_FILE_PATH = "VARDEF_DESCRIPTIONS_FILE_PATH"
+VARDEF_DEFAULT_DESCRIPTION_PATH = "src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml"
 
 
 def get_descriptions_path() -> str:
@@ -19,9 +22,14 @@ def get_descriptions_path() -> str:
         str: The file path to the descriptions.
     """
     return (
-        get_config_item("VARDEF_DESCRIPTIONS_FILE_PATH")
-        or "src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml"
+        get_config_item(VARDEF_DESCRIPTIONS_FILE_PATH)
+        or VARDEF_DEFAULT_DESCRIPTION_PATH
     )
+
+
+def get_workspace_dir() -> str:
+    """Get the path to work directory from workspace environment variable."""
+    return get_config_item("WORKSPACE_DIR")
 
 
 def get_active_group() -> str:

--- a/src/dapla_metadata/variable_definitions/config.py
+++ b/src/dapla_metadata/variable_definitions/config.py
@@ -27,7 +27,7 @@ def get_descriptions_path() -> str:
     )
 
 
-def get_workspace_dir() -> str | None:
+def get_workspace_dir() -> str:
     """Get the path to work directory from workspace environment variable."""
     return get_config_item("WORKSPACE_DIR")
 

--- a/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
@@ -12,6 +12,7 @@ from ruamel.yaml import CommentedMap
 
 from dapla_metadata.variable_definitions import config
 from dapla_metadata.variable_definitions.complete_patch_output import DEFAULT_TEMPLATE
+from dapla_metadata.variable_definitions.exceptions import VardefFileError
 from dapla_metadata.variable_definitions.generated.vardef_client.models.complete_response import (
     CompleteResponse,
 )
@@ -226,7 +227,7 @@ def _get_workspace_dir() -> Path:
 
     if workspace_dir is None:
         msg = "WORKSPACE_DIR is not set in the configuration."
-        raise ValueError(msg)
+        raise VardefFileError(msg)
 
     if not isinstance(workspace_dir, str | Path):
         msg = f"Expected WORKSPACE_DIR to be a string or Path, but got {type(workspace_dir).__name__}"

--- a/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
@@ -229,11 +229,12 @@ def _get_workspace_dir() -> Path:
         msg = "WORKSPACE_DIR is not set in the configuration."
         raise VardefFileError(msg)
 
-    if not isinstance(workspace_dir, str | Path):
+    if not isinstance(workspace_dir, (str | None)):
         msg = f"Expected WORKSPACE_DIR to be a string or Path, but got {type(workspace_dir).__name__}"
         raise TypeError
 
-    workspace_dir = Path(workspace_dir).resolve()
+    workspace_dir = Path(workspace_dir)
+    workspace_dir.resolve()
 
     if not workspace_dir.exists():
         msg = f"Directory '{workspace_dir}' does not exist."

--- a/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
@@ -230,7 +230,6 @@ def _get_workspace_dir() -> Path:
         raise VardefFileError(msg)
     workspace_dir_path: Path
     if workspace_dir is not None:
-        logger.info("'WORKSPACE_DIR' value: %s", workspace_dir)
         workspace_dir_path = Path(workspace_dir)
         workspace_dir_path.resolve()
 
@@ -241,6 +240,7 @@ def _get_workspace_dir() -> Path:
         if not workspace_dir_path.is_dir():
             msg = f"'{workspace_dir_path}' is not a directory."
             raise NotADirectoryError(msg)
+        logger.debug("'WORKSPACE_DIR' value: %s", workspace_dir)
     return workspace_dir_path
 
 

--- a/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
@@ -226,7 +226,7 @@ def _get_workspace_dir() -> Path:
     workspace_dir = config.get_workspace_dir()
 
     if workspace_dir is None:
-        msg = "WORKSPACE_DIR is not set in the configuration."
+        msg = "WORKSPACE_DIR is not set. Check your configuration or provide a custom directory."
         raise VardefFileError(msg)
     workspace_dir_path: Path
     if workspace_dir is not None:

--- a/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
@@ -228,23 +228,20 @@ def _get_workspace_dir() -> Path:
     if workspace_dir is None:
         msg = "WORKSPACE_DIR is not set in the configuration."
         raise VardefFileError(msg)
+    workspace_dir_path: Path
+    if workspace_dir is not None:
+        logger.info("'WORKSPACE_DIR' value: %s", workspace_dir)
+        workspace_dir_path = Path(workspace_dir)
+        workspace_dir_path.resolve()
 
-    if not isinstance(workspace_dir, (str | None)):
-        msg = f"Expected WORKSPACE_DIR to be a string or Path, but got {type(workspace_dir).__name__}"
-        raise TypeError
+        if not workspace_dir_path.exists():
+            msg = f"Directory '{workspace_dir_path}' does not exist."
+            raise FileNotFoundError(msg)
 
-    workspace_dir = Path(workspace_dir)
-    workspace_dir.resolve()
-
-    if not workspace_dir.exists():
-        msg = f"Directory '{workspace_dir}' does not exist."
-        raise FileNotFoundError(msg)
-
-    if not workspace_dir.is_dir():
-        msg = f"'{workspace_dir}' is not a directory."
-        raise NotADirectoryError(msg)
-
-    return workspace_dir
+        if not workspace_dir_path.is_dir():
+            msg = f"'{workspace_dir_path}' is not a directory."
+            raise NotADirectoryError(msg)
+    return workspace_dir_path
 
 
 def _validate_and_create_directory(custom_directory: Path) -> Path:

--- a/src/dapla_metadata/variable_definitions/vardef.py
+++ b/src/dapla_metadata/variable_definitions/vardef.py
@@ -29,8 +29,6 @@ from dapla_metadata.variable_definitions.variable_definition import VariableDefi
 
 logger = logging.getLogger(__name__)
 
-logger = logging.getLogger(__name__)
-
 
 class Vardef:
     """Create, maintain and read Variable Definitions.

--- a/tests/variable_definitions/conftest.py
+++ b/tests/variable_definitions/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from dapla_metadata.variable_definitions.config import get_descriptions_path
+from dapla_metadata.variable_definitions import config
 from dapla_metadata.variable_definitions.generated import vardef_client
 from dapla_metadata.variable_definitions.generated.vardef_client.api_client import (
     ApiClient,
@@ -258,16 +258,7 @@ def set_temp_workspace(tmp_path: Path):
 
 
 @pytest.fixture
-def set_env_work_dir(tmp_path: Path):
-    """Fixture which set env WORKSPACE_DIR to tmp path/work."""
-    workspace_dir = tmp_path / "work"
-    os.environ["WORKSPACE_DIR"] = str(workspace_dir)
-    return workspace_dir
-
-
-@pytest.fixture
-def set_temp_workspace_invalid(tmp_path: Path, _delete_workspace_dir):
-    """Fixture which set env WORKSPACE_DIR to tmp path/work."""
+def set_temp_workspace_invalid(tmp_path: Path):
     workspace_dir = tmp_path / "statistics"
     workspace_dir.mkdir(parents=True, exist_ok=True)
     return workspace_dir
@@ -290,7 +281,7 @@ def work_folder_defaults(set_temp_workspace: Path):
 
 
 @pytest.fixture
-def work_folder_saved_variable(set_temp_workspace: Path):
+def work_folder_complete_patch_output(set_temp_workspace: Path):
     """Fixture that ensures a work folder exists for template with saved variable definition values."""
     base_path = set_temp_workspace
     file_name = create_template_yaml(
@@ -304,26 +295,8 @@ def work_folder_saved_variable(set_temp_workspace: Path):
 
 
 @pytest.fixture
-def work_folder_saved_variable_2(
-    set_temp_workspace: Path,
-    sample_variable_definition: VariableDefinition,
-):
-    """Fixture that ensures a work folder exists for template with saved variable definition values."""
-    base_path = set_temp_workspace
-    file_name = create_template_yaml(
-        sample_variable_definition,
-        custom_directory=base_path,
-    )
-    target_path = base_path / file_name
-    yield target_path
-
-    _clean_up_after_test(target_path, base_path)
-
-
-@pytest.fixture
 def _delete_workspace_dir():
-    original_workspace_dir = os.environ.get("WORKSPACE_DIR")
-
+    original_workspace_dir = config.get_workspace_dir()
     if "WORKSPACE_DIR" in os.environ:
         del os.environ["WORKSPACE_DIR"]
 
@@ -388,4 +361,4 @@ VARIABLE_DEFINITION_DICT = {
 @pytest.fixture
 def get_norwegian_descriptions_from_file():
     """Return dict representation of model field descriptions."""
-    return load_descriptions(get_descriptions_path())
+    return load_descriptions(config.get_descriptions_path())

--- a/tests/variable_definitions/conftest.py
+++ b/tests/variable_definitions/conftest.py
@@ -372,3 +372,10 @@ VARIABLE_DEFINITION_DICT = {
 def get_norwegian_descriptions_from_file():
     """Return dict representation of model field descriptions."""
     return load_descriptions(config.get_descriptions_path())
+
+
+@pytest.fixture
+def set_workspace_not_dir(tmp_path: Path):
+    file_path = tmp_path / "funnyfiles.txt"
+    file_path.write_text("This is a text file.")
+    return file_path

--- a/tests/variable_definitions/test_config.py
+++ b/tests/variable_definitions/test_config.py
@@ -4,10 +4,15 @@ from dapla_metadata._shared.config import DAPLA_ENVIRONMENT
 from dapla_metadata._shared.config import DAPLA_GROUP_CONTEXT
 from dapla_metadata._shared.config import OIDC_TOKEN
 from dapla_metadata._shared.enums import DaplaEnvironment
+from dapla_metadata.variable_definitions.config import VARDEF_DEFAULT_DESCRIPTION_PATH
+from dapla_metadata.variable_definitions.config import VARDEF_DESCRIPTIONS_FILE_PATH
 from dapla_metadata.variable_definitions.config import VARDEF_HOST_TEST
+from dapla_metadata.variable_definitions.config import WORKSPACE_DIR
 from dapla_metadata.variable_definitions.config import get_active_group
+from dapla_metadata.variable_definitions.config import get_descriptions_path
 from dapla_metadata.variable_definitions.config import get_vardef_client_configuration
 from dapla_metadata.variable_definitions.config import get_vardef_host
+from dapla_metadata.variable_definitions.config import get_workspace_dir
 
 
 @pytest.mark.parametrize(
@@ -72,3 +77,18 @@ def test_active_group_unset(monkeypatch: pytest.MonkeyPatch):
 def test_active_group_set(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(DAPLA_GROUP_CONTEXT, "my-group")
     assert get_active_group() == "my-group"
+
+
+def test_workspace_dir_set(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(WORKSPACE_DIR, "home/work")
+    assert get_workspace_dir() == "home/work"
+
+
+def test_description_path_set(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(VARDEF_DESCRIPTIONS_FILE_PATH, "path/home/file.yaml")
+    assert get_descriptions_path() == "path/home/file.yaml"
+
+
+def test_description_path_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(VARDEF_DESCRIPTIONS_FILE_PATH, raising=False)
+    assert get_descriptions_path() == VARDEF_DEFAULT_DESCRIPTION_PATH

--- a/tests/variable_definitions/test_template.py
+++ b/tests/variable_definitions/test_template.py
@@ -41,9 +41,9 @@ def test_yaml_content_default_values(work_folder_defaults: Path):
     assert parsed_yaml["owner"]["team"] == "default team"
 
 
-def test_yaml_content_saved_values(work_folder_saved_variable: Path) -> None:
+def test_yaml_content_saved_values(work_folder_complete_patch_output: Path) -> None:
     """Check if the generated YAML file with saved values contains the expected data."""
-    with work_folder_saved_variable.open(encoding="utf-8") as f:
+    with work_folder_complete_patch_output.open(encoding="utf-8") as f:
         parsed_yaml = yaml.load(f)
 
     assert parsed_yaml["variable_status"] == "PUBLISHED_INTERNAL"

--- a/tests/variable_definitions/test_vardef_write_template.py
+++ b/tests/variable_definitions/test_vardef_write_template.py
@@ -21,7 +21,7 @@ def test_write_template_no_workspace(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("WORKSPACE_DIR", raising=False)
     with pytest.raises(
         VardefFileError,
-        match="VardefFileError: WORKSPACE_DIR is not set in the configuration.",
+        match="VardefFileError: WORKSPACE_DIR is not set",
     ):
         Vardef.write_template_to_file()
 

--- a/tests/variable_definitions/test_vardef_write_template.py
+++ b/tests/variable_definitions/test_vardef_write_template.py
@@ -17,21 +17,12 @@ def test_write_template(tmp_path: Path):
 
 
 @pytest.mark.usefixtures("_delete_workspace_dir")
-def test_write_template_no_workspace(tmp_path: Path):
-    with patch.object(Path, "cwd", return_value=tmp_path), pytest.raises(
-        VardefFileError,
-        match="VardefFileError: File not found at file path: unknown file path",
+def test_write_template_no_workspace():
+    with pytest.raises(
+        ValueError,
+        match="WORKSPACE_DIR is not set in the configuration.",
     ):
         Vardef.write_template_to_file()
-
-
-@pytest.mark.usefixtures("_delete_workspace_dir")
-def test_write_template_path_no_env_value(tmp_path: Path):
-    workspace_dir = tmp_path / "work"
-    workspace_dir.mkdir(parents=True, exist_ok=True)
-    with patch.object(Path, "cwd", return_value=workspace_dir):
-        file_path = Vardef.write_template_to_file()
-    assert file_path.exists()
 
 
 def test_write_template_from_tmp_path():
@@ -39,32 +30,6 @@ def test_write_template_from_tmp_path():
     with patch.object(Path, "cwd", return_value=base_path):
         file_path = Vardef.write_template_to_file()
         assert file_path.exists()
-
-
-@pytest.mark.usefixtures("_delete_workspace_dir")
-@pytest.mark.usefixtures("set_temp_workspace_invalid")
-def test_write_template_invalid():
-    """Env 'WORKSPACE_DIR' not present and 'work' not on path."""
-    base_path = Path("../")
-    base_path.mkdir(parents=True, exist_ok=True)
-
-    with patch.object(Path, "cwd", return_value=base_path), pytest.raises(
-        VardefFileError,
-        match="VardefFileError: File not found at file path: unknown file path. Original error: 'work' directory not found and env WORKSPACE_DIR is not set.",
-    ):
-        Vardef.write_template_to_file()
-
-
-@pytest.mark.usefixtures("_delete_workspace_dir")
-def test_write_template_no_work_folder(tmp_path: Path):
-    base_path = tmp_path / "statistics/a/"
-    base_path.mkdir(parents=True, exist_ok=True)
-
-    with patch.object(Path, "cwd", return_value=base_path), pytest.raises(
-        VardefFileError,
-        match="VardefFileError: File not found at file path: unknown file path",
-    ):
-        Vardef.write_template_to_file()
 
 
 @pytest.mark.usefixtures("set_temp_workspace")

--- a/tests/variable_definitions/test_vardef_write_template.py
+++ b/tests/variable_definitions/test_vardef_write_template.py
@@ -41,6 +41,7 @@ def test_write_template_from_tmp_path():
         assert file_path.exists()
 
 
+@pytest.mark.usefixtures("_delete_workspace_dir")
 @pytest.mark.usefixtures("set_temp_workspace_invalid")
 def test_write_template_invalid():
     """Env 'WORKSPACE_DIR' not present and 'work' not on path."""
@@ -54,9 +55,9 @@ def test_write_template_invalid():
         Vardef.write_template_to_file()
 
 
-@pytest.mark.usefixtures("set_env_work_dir")
+@pytest.mark.usefixtures("_delete_workspace_dir")
 def test_write_template_no_work_folder(tmp_path: Path):
-    base_path = tmp_path / "statistics/a/work"
+    base_path = tmp_path / "statistics/a/"
     base_path.mkdir(parents=True, exist_ok=True)
 
     with patch.object(Path, "cwd", return_value=base_path), pytest.raises(

--- a/tests/variable_definitions/test_vardef_write_template.py
+++ b/tests/variable_definitions/test_vardef_write_template.py
@@ -21,7 +21,7 @@ def test_write_template_no_workspace(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("WORKSPACE_DIR", raising=False)
     with pytest.raises(
         VardefFileError,
-        match="VardefFileError: File not found at file path: unknown file path",
+        match="VardefFileError: WORKSPACE_DIR is not set in the configuration.",
     ):
         Vardef.write_template_to_file()
 

--- a/tests/variable_definitions/test_vardef_write_template.py
+++ b/tests/variable_definitions/test_vardef_write_template.py
@@ -170,3 +170,10 @@ def test_write_template_exceptions(mock_target: str, side_effect: Exception, moc
 
     with pytest.raises(VardefFileError):
         Vardef.write_template_to_file()
+
+
+def test_logging_workspace_dir(caplog):
+    """Test logging intended for user."""
+    caplog.set_level(logging.INFO)
+    Vardef.write_template_to_file()
+    assert "Created editable variable definition template file" in caplog.text

--- a/tests/variable_definitions/test_variable_definition_files.py
+++ b/tests/variable_definitions/test_variable_definition_files.py
@@ -1,0 +1,36 @@
+import logging
+
+import pytest
+
+from dapla_metadata.variable_definitions.exceptions import VardefFileError
+from dapla_metadata.variable_definitions.utils.variable_definition_files import (
+    _get_workspace_dir,
+)
+
+
+def test_logging_workspace_dir(caplog):
+    """Test logging intended for debugging."""
+    caplog.set_level(logging.DEBUG)
+    _get_workspace_dir()
+    assert "WORKSPACE_DIR' value:" in caplog.text
+
+
+def test_workspace_dir_not_set(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("WORKSPACE_DIR", raising=False)
+    with pytest.raises(
+        VardefFileError,
+        match="VardefFileError: WORKSPACE_DIR is not set in the configuration.",
+    ):
+        _get_workspace_dir()
+
+
+def test_workspace_dir_doesnt_exist(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WORKSPACE_DIR", "funnypath/haha")
+    with pytest.raises(FileNotFoundError):
+        _get_workspace_dir()
+
+
+def test_workspace_is_not_dir(monkeypatch: pytest.MonkeyPatch, set_workspace_not_dir):
+    monkeypatch.setenv("WORKSPACE_DIR", str(set_workspace_not_dir))
+    with pytest.raises(NotADirectoryError):
+        _get_workspace_dir()

--- a/tests/variable_definitions/test_variable_definition_files.py
+++ b/tests/variable_definitions/test_variable_definition_files.py
@@ -19,7 +19,7 @@ def test_workspace_dir_not_set(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("WORKSPACE_DIR", raising=False)
     with pytest.raises(
         VardefFileError,
-        match="VardefFileError: WORKSPACE_DIR is not set in the configuration.",
+        match="VardefFileError: WORKSPACE_DIR is not set",
     ):
         _get_workspace_dir()
 


### PR DESCRIPTION
- Read env value "WORKSPACE_DIR" from config.  This method can return `None` if no value.
- Handle the potential null value when determining workspace directory:
   - Should be a `VardefFileError` because user can choose to provide a custom path or check/correct


