### PR TITLE
Suppress Pydantic warnings

### DIFF
--- a/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/utils/variable_definition_files.py
@@ -77,7 +77,11 @@ def _model_to_yaml_with_comments(
     apply_norwegian_descriptions_to_model(CompletePatchOutput)
     apply_norwegian_descriptions_to_model(VariableDefinition)
 
-    data = model_instance.model_dump()  # Convert Pydantic model instance to dictionary
+    # Convert Pydantic model instance to dictionary
+    data = model_instance.model_dump(
+        serialize_as_any=True,
+        warnings="error",
+    )
 
     # One CommentMap for each section in the yaml file
     machine_generated_map = CommentedMap()


### PR DESCRIPTION
Suppress warnings like the following when writing a variable to file

```
my_draft = Vardef.write_variable_to_file(short_name="arbkonfl")

Warning: Pydantic serializer warnings:
  Expected `LanguageStringType` but got `dict` with value `{'nb': 'Tapte arbeidsdage...n': 'Working days lost'}` - serialized value may not be as expected
  Expected `LanguageStringType` but got `dict` with value `{'nb': 'Varigheten av en ...es, not calendar days.'}` - serialized value may not be as expected
  Expected `Owner` but got `dict` with value `{'team': 'dapla-felles', ...pla-felles-developers']}` - serialized value may not be as expected
  Expected `Contact` but got `dict` with value `{'title': {'nb': 'generer...': 'generert@epost.com'}` - serialized value may not be as expected, Category: UserWarning, Filename: /Users/mmw/Library/Caches/pypoetry/virtualenvs/dapla-toolbelt-metadata-9NhZ1fWH-py3.12/lib/python3.12/site-packages/pydantic/main.py, Line: 426
```