### PR TITLE
Notebook: publish draft

### DIFF
--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -9,7 +9,7 @@
     "Denne Notebook er for deg som:\n",
     "\n",
     "- Har en kvalitetsjekket variabeldefinisjon med status `UTKAST`\n",
-    "- Ønsker å publisere internt\n",
+    "- Ønsker å publisere internt eller eksternt\n",
     "\n",
     "Forutsetninger:\n",
     "- Du må ha enten `Kortnavn` eller `id` for variabeldefinisjonen du vil publisere\n",
@@ -58,7 +58,7 @@
     "# Gjøre at logging vises\n",
     "logging.basicConfig(\n",
     "    format=\"%(levelname)s: %(message)s\",\n",
-    "    level=logging.WARNING,\n",
+    "    level=logging.INFO,\n",
     "    stream=sys.stdout,\n",
     "    force=True,\n",
     ")"
@@ -82,9 +82,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hvis du har `Kortnavn` velg [Kortnavn](#kortnavn)\n",
+    "Hvis du har `Kortnavn` velg [Variabeldefinisjon fra kortnavn](#Variabeldefinisjon-fra-kortnavn)\n",
     "\n",
-    "Hvis du har `Id`  velg [Id](#id)\n",
+    "Hvis du har `Id`  velg [Variabeldefinisjon fra id](#Variabeldefinisjon-fra-id)\n",
     "\n",
     "NB! Velg kun en av metodene for å unngå feil.\n",
     "\n",
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Kortnavn"
+    "#### Variabeldefinisjon fra kortnavn"
    ]
   },
   {
@@ -105,24 +105,16 @@
    "outputs": [],
    "source": [
     "# Sett inn kortnavn mellom anførselstegn\n",
-    "mitt_kortnavn = \"\"\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "mitt_kortnavn = \"\"\n",
     "# Lagre variabeldefinisjonen i minnet\n",
-    "min_variabel = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn)"
+    "min_variabel = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Id"
+    "#### Variabeldefinisjon fra id"
    ]
   },
   {
@@ -132,17 +124,9 @@
    "outputs": [],
    "source": [
     "# Sett inn id mellom anførselstegn\n",
-    "min_id = \"\"\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Lagre variabeldefinisjon i minnet med navnet '\n",
-    "min_variabel= Vardef.get_variable_definition_by_id(id=min_id)"
+    "min_id = \"\"\n",
+    "# Lagre variabeldefinisjon i minnet \n",
+    "min_variabel= Vardef.get_variable_definition_by_id(id=min_id)\n"
    ]
   },
   {
@@ -159,7 +143,7 @@
    "outputs": [],
    "source": [
     "# Publisere internt\n",
-    "min_variabel_status = models.VariableStatus.PUBLISHED_INTERNAL"
+    "status_internt = models.VariableStatus.PUBLISHED_INTERNAL"
    ]
   },
   {
@@ -168,8 +152,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "min_oppdatering = models.UpdateDraft(variable_status=min_variabel_status)\n"
+    "# Publisere eksternt\n",
+    "status_eksternt = models.VariableStatus.PUBLISHED_EXTERNAL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Under bytter du ut `None` med valgt status, enten `status_internt` eller `status_eksternt`"
    ]
   },
   {
@@ -178,6 +169,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Bytt ut None med status\n",
+    "min_status = None\n",
+    "min_oppdatering = models.UpdateDraft(variable_status=min_status)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Her lagrer vi endringen i Vardef\n",
     "min_variabel.update_draft(min_oppdatering)"
    ]
   },
@@ -194,8 +197,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Oppdater variabel\n",
-    "min_variabel = Vardef.get_variable_definition_by_shortname(mitt_kortnavn)"
+    "# Sjekk status med id\n",
+    "print(Vardef.get_variable_definition_by_id(min_id).variable_status)"
    ]
   },
   {
@@ -204,8 +207,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sjekk status\n",
-    "print(min_variabel.variable_status)"
+    "# Sjekk status med kortnavn\n",
+    "print(Vardef.get_variable_definition_by_shortname(mitt_kortnavn).variable_status)"
    ]
   },
   {

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -126,7 +126,7 @@
     "# Sett inn id mellom anførselstegn\n",
     "min_id = \"\"\n",
     "# Lagre variabeldefinisjon i minnet \n",
-    "min_variabel= Vardef.get_variable_definition_by_id(id=min_id)\n"
+    "min_variabel= Vardef.get_variable_definition_by_id(variable_definition_id=min_id)\n"
    ]
   },
   {
@@ -160,7 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Under bytter du ut `None` med valgt status, enten `status_internt` eller `status_eksternt`"
+    "I koden under bytter du ut `None` med valgt status, enten `status_internt` eller `status_eksternt`"
    ]
   },
   {
@@ -180,7 +180,7 @@
    "source": [
     "### Lagre i Vardef\n",
     "\n",
-    "Under lagrer vi den oppdarte statusen i Vardef. Dette steget er essensielt for å endre statusen og må gjennomføres uten feilmeldinger. Er du usikker om det var vellykket kan du gå videre til [Bekrefte publisering](#bekrefte-publisering) og hvis status er uendret forsøke på nytt."
+    "I koden under lagrer vi den oppdaterte statusen i Vardef. Dette steget er essensielt for å endre statusen og må gjennomføres uten feilmeldinger. Er du usikker om det var vellykket kan du gå videre til [Bekrefte publisering](#bekrefte-publisering) og hvis status er uendret forsøke på nytt."
    ]
   },
   {
@@ -206,8 +206,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sjekk status med id\n",
-    "print(Vardef.get_variable_definition_by_id(min_id).variable_status)"
+    "# Sjekk status med kortnavn\n",
+    "print(Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn).variable_status)"
    ]
   },
   {
@@ -216,8 +216,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sjekk status med kortnavn\n",
-    "print(Vardef.get_variable_definition_by_shortname(mitt_kortnavn).variable_status)"
+    "# Sjekk status med id\n",
+    "print(Vardef.get_variable_definition_by_id(variable_definition_id=min_id).variable_status)"
    ]
   },
   {
@@ -281,9 +281,9 @@
    "outputs": [],
    "source": [
     "# Sett inn id mellom anførselstegn\n",
-    "min_id = \"\"\n",
+    "min_id_yaml = \"\"\n",
     "# Lagre variabeldefinisjon i minnet med navnet '\n",
-    "min_variabel_yaml= Vardef.get_variable_definition_by_id(id=min_id)"
+    "min_variabel_yaml= Vardef.get_variable_definition_by_id(variable_definition_id=min_id_yaml)"
    ]
   },
   {
@@ -314,10 +314,10 @@
    "source": [
     "### Rediger YAML-fil\n",
     "\n",
-    "1. Åpne YAML-fil med korrekt filnavn \n",
+    "1. Åpne YAML-fil med korrekt filnavn. \n",
     "Hvis du har flere filer sørg for at du redigerer filen der filnavnet inneholder:\n",
     "-  Korrekt kortnavn og id (begge er unike så hvis kortnavn er korrekt må også id være korrekt)\n",
-    "-  Hvis flere har samme kortnavn/id sammenlign tidspunkt (Timestamp) i filnavnet. \n",
+    "-  Hvis flere har samme kortnavn/id sammenlign tidspunkt (Timestamp) i filnavnet. Velg seneste tidspunkt.\n",
     "-  Er du usikker slett alle filer for variabelen og kjør forrige steg på nytt\n",
     "2. Finn feltet `variabel_status`\n",
     "3. Endre verdien fra `DRAFT` til enten `PUBLISHED_INTERNAL` eller `PUBLISHED_EXTERNAL`"
@@ -337,6 +337,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Her lagrer vi endringen i Vardef\n",
     "min_variabel_yaml.update_draft_from_file()"
    ]
   },
@@ -354,7 +355,7 @@
    "outputs": [],
    "source": [
     "# Bruk kortnavn\n",
-    "print(Vardef.get_variable_definition_by_shortname(mitt_kortnavn).variable_status)"
+    "print(Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn_yaml).variable_status)"
    ]
   },
   {
@@ -364,7 +365,7 @@
    "outputs": [],
    "source": [
     "# Bruk id\n",
-    "print(Vardef.get_variable_definition_by_id(min_id).variable_status)"
+    "print(Vardef.get_variable_definition_by_id(variable_definition_id=min_id_yaml).variable_status)"
    ]
   }
  ],

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -170,7 +170,7 @@
    "outputs": [],
    "source": [
     "# Bytt ut None med status\n",
-    "min_status = None\n",
+    "min_status = status_internt\n",
     "min_oppdatering = models.UpdateDraft(variable_status=min_status)"
    ]
   },

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -16,18 +16,34 @@
     "\n",
     "Du kan velge to metoder:\n",
     "- Kodebasert metode: Oppdater status direkte i kode\n",
-    "- Fil-basert metode: Lag en YAML-fil og oppdater status med fil\n"
+    "- Fil-basert metode: Lag en YAML-fil og oppdater status med fil"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
     "Innhold:\n",
     "* [Oppsett](#oppsett)\n",
     "* [Publiserer med kode](#Kodebasert-metode)\n",
     "* [Publisere med fil](#fil-basert-metode)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Viktig informasjon om publisering\n",
+    "\n",
+    "Merk at prosessen med å publisere er irreversibel. Når en variabeldefinisjon er publisert kan den ikke avpubliseres eller slettes.\n",
+    "\n",
+    "Det er ulike regler som gjelder ved publisering internt og eksternt.\n",
+    "\n",
+    "Ved intern publisering må alle obligatoriske felt ha verdi.\n",
+    "\n",
+    "Ved ekstern publisere må i tillegg alle felt som er flerspråklige ha verdier på alle språk (bokmål, nynorsk og engelsk).\n",
+    "\n",
+    "Merk også at når en variabeldefinisjon er publisert eksternt kan den ikke endres tilbake til å kun være publisert internt."
    ]
   },
   {
@@ -180,7 +196,9 @@
    "source": [
     "### Lagre i Vardef\n",
     "\n",
-    "I koden under lagrer vi den oppdaterte statusen i Vardef. Dette steget er essensielt for å endre statusen og må gjennomføres uten feilmeldinger. Er du usikker om det var vellykket kan du gå videre til [Bekrefte publisering](#bekrefte-publisering) og hvis status er uendret forsøke på nytt."
+    "I koden under lagrer vi den oppdaterte statusen i Vardef. Dette steget er essensielt for å endre statusen og må gjennomføres uten feilmeldinger. \n",
+    "\n",
+    "Er du usikker om det var vellykket kan du gå videre til [Bekrefte publisering](#bekrefte-publisering) og hvis status er uendret forsøke på nytt."
    ]
   },
   {
@@ -327,8 +345,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Lagre endringer\n",
-    "Under lagrer vi den oppdarte statusen i Vardef. Dette steget er essensielt for å endre statusen og må gjennomføres uten feilmeldinger. Er du usikker om det var vellykket kan du gå videre til [Bekrefte publisering filbasert metode](#bekrefte-publisering-fil-basert-metode) og hvis status er uendret forsøke på nytt."
+    "### Lagre i Vardef fil-basert\n",
+    "I koden under lagrer vi den oppdaterte statusen i Vardef. Dette steget er essensielt for å endre statusen og må gjennomføres uten feilmeldinger.\n",
+    "\n",
+    "Er du usikker om det var vellykket kan du gå videre til [Bekrefte publisering filbasert metode](#bekrefte-publisering-fil-basert-metode) og hvis status er uendret forsøke på nytt.\n"
    ]
   },
   {

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -223,13 +223,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Skrive variabeldefinisjon til YAML-fil\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Hente ut variabeldefinisjon ved hjelp av `Kortnavn` eller `id`"
    ]
   },
@@ -237,11 +230,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hvis du har `Kortnavn` velg [Kortnavn](#kortnavn)\n",
+    "Hvis du har `Kortnavn` velg [YAML-fil med kortnavn](#YAML-fil-med-kortnavn)\n",
     "\n",
-    "Hvis du har `Id`  velg [Id](#id)\n",
+    "Hvis du har `Id`  velg [YAML-fil med id](#YAML-fil-med-id)\n",
     "\n",
-    "NB! Velg kun en av metodene for å unngå feil.\n"
+    "NB! Velg kun en av metodene for å unngå feil.\n",
+    "\n",
+    "Gå deretter videre til [Skriv til fil](#Skriv-til-fil)\n"
    ]
   },
   {
@@ -258,24 +253,16 @@
    "outputs": [],
    "source": [
     "# Sett inn kortnavn mellom anførselstegn\n",
-    "mitt_kortnavn_yaml = \"\"\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "mitt_kortnavn_yaml = \"\"\n",
     "# Lagre variabeldefinisjonen i minnet\n",
-    "min_variabel_yaml = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn_yaml)"
+    "min_variabel_yaml = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn_yaml)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### YAML-fil med ID"
+    "#### YAML-fil med id"
    ]
   },
   {
@@ -285,26 +272,9 @@
    "outputs": [],
    "source": [
     "# Sett inn id mellom anførselstegn\n",
-    "min_id = \"\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "min_id = \"\"\n",
     "# Lagre variabeldefinisjon i minnet med navnet '\n",
     "min_variabel_yaml= Vardef.get_variable_definition_by_id(id=min_id)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "var = Vardef.write_variable_to_file(id=min_id)"
    ]
   },
   {
@@ -330,8 +300,12 @@
     "### Rediger YAML-fil\n",
     "\n",
     "1. Åpne YAML-fil med korrekt filnavn \n",
+    "Hvis du har flere filer sørg for at du redigerer der filnavnet inneholder:\n",
+    "-  Korrekt kortnavn og id (begge er unike så hvis kortnavn er korrekt må også id være korrekt)\n",
+    "-  Seneste tidspunkt i filnavn\n",
+    "-  Er du usikker slett alle filer og kjør forrige steg på nytt\n",
     "2. Finn feltet `variabel_status`\n",
-    "3. Endre verdien til enten `PUBLISHED_INTERNAL`"
+    "3. Endre verdien fra `DRAFT` til enten `PUBLISHED_INTERNAL` eller `PUBLISHED_EXTERNAL`"
    ]
   },
   {

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -360,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
+    "# Bruk kortnavn\n",
     "print(Vardef.get_variable_definition_by_shortname(mitt_kortnavn).variable_status)"
    ]
   },
@@ -370,6 +370,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Bruk id\n",
     "print(Vardef.get_variable_definition_by_id(min_id).variable_status)"
    ]
   }

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -175,6 +175,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lagre i Vardef\n",
+    "\n",
+    "Under lagrer vi den oppdarte statusen i Vardef. Dette steget er essensielt for å endre statusen og må gjennomføres uten feilmeldinger. Er du usikker om det var vellykket kan du gå videre til [Bekrefte publisering](#bekrefte-publisering) og hvis status er uendret forsøke på nytt."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -281,7 +290,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Skriv til fil"
+    "### Skriv til fil\n",
+    "Opprettes som standard på `/home/onyxia/work/variable_definitions/variable_definition_<kortnavn>_<id>_<timestamp>.yaml`.\n",
+    "\n",
+    "Filen vil inneholde alle lagrede verdier for variabeldefinisjonen.\n",
+    "\n",
+    "\n"
    ]
   },
   {
@@ -290,6 +304,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Lagre fil\n",
     "min_variabel_yaml.to_file()"
    ]
   },
@@ -300,10 +315,10 @@
     "### Rediger YAML-fil\n",
     "\n",
     "1. Åpne YAML-fil med korrekt filnavn \n",
-    "Hvis du har flere filer sørg for at du redigerer der filnavnet inneholder:\n",
+    "Hvis du har flere filer sørg for at du redigerer filen der filnavnet inneholder:\n",
     "-  Korrekt kortnavn og id (begge er unike så hvis kortnavn er korrekt må også id være korrekt)\n",
-    "-  Seneste tidspunkt i filnavn\n",
-    "-  Er du usikker slett alle filer og kjør forrige steg på nytt\n",
+    "-  Hvis flere har samme kortnavn/id sammenlign tidspunkt (Timestamp) i filnavnet. \n",
+    "-  Er du usikker slett alle filer for variabelen og kjør forrige steg på nytt\n",
     "2. Finn feltet `variabel_status`\n",
     "3. Endre verdien fra `DRAFT` til enten `PUBLISHED_INTERNAL` eller `PUBLISHED_EXTERNAL`"
    ]
@@ -312,7 +327,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Lagre endringer"
+    "### Lagre endringer\n",
+    "Under lagrer vi den oppdarte statusen i Vardef. Dette steget er essensielt for å endre statusen og må gjennomføres uten feilmeldinger. Er du usikker om det var vellykket kan du gå videre til [Bekrefte publisering filbasert metode](#bekrefte-publisering-fil-basert-metode) og hvis status er uendret forsøke på nytt."
    ]
   },
   {
@@ -328,7 +344,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Bekrefte publisering og sjekke status"
+    "### Bekrefte publisering fil-basert metode"
    ]
   },
   {

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -100,7 +100,7 @@
    "source": [
     "Hvis du har `Kortnavn` velg [Variabeldefinisjon fra kortnavn](#Variabeldefinisjon-fra-kortnavn)\n",
     "\n",
-    "Hvis du har `Id`  velg [Variabeldefinisjon fra id](#Variabeldefinisjon-fra-id)\n",
+    "Hvis du har `id`  velg [Variabeldefinisjon fra id](#Variabeldefinisjon-fra-id)\n",
     "\n",
     "NB! Velg kun en av metodene for å unngå feil.\n",
     "\n",
@@ -259,7 +259,7 @@
    "source": [
     "Hvis du har `Kortnavn` velg [YAML-fil med kortnavn](#YAML-fil-med-kortnavn)\n",
     "\n",
-    "Hvis du har `Id`  velg [YAML-fil med id](#YAML-fil-med-id)\n",
+    "Hvis du har `id`  velg [YAML-fil med id](#YAML-fil-med-id)\n",
     "\n",
     "NB! Velg kun en av metodene for å unngå feil.\n",
     "\n",
@@ -300,7 +300,7 @@
    "source": [
     "# Sett inn id mellom anførselstegn\n",
     "min_id_yaml = \"\"\n",
-    "# Lagre variabeldefinisjon i minnet med navnet '\n",
+    "# Lagre variabeldefinisjon i minnet\n",
     "min_variabel_yaml= Vardef.get_variable_definition_by_id(variable_definition_id=min_id_yaml)"
    ]
   },

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -1,0 +1,114 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Publisere utkast\n",
+    "\n",
+    "Innhold:\n",
+    "* [Oppsett](#Oppsett)\n",
+    "* [Publisere fra fil](#Publisere-fra-fil)\n",
+    "* [Publiserer kode](#)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Oppsett\n",
+    "\n",
+    "Koden under kjøres som forberedelse for påfølgende steg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Nødvendig import\n",
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "from dapla_metadata.variable_definitions import Vardef\n",
+    "from dapla_metadata.variable_definitions import models\n",
+    "\n",
+    "# Redusere størrelsen på Traceback for mer tydelige feilmeldinger\n",
+    "%xmode Minimal\n",
+    "\n",
+    "# Gjøre at logging vises\n",
+    "logging.basicConfig(\n",
+    "    format=\"%(levelname)s: %(message)s\",\n",
+    "    level=logging.INFO,\n",
+    "    stream=sys.stdout,\n",
+    "    force=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Internt\n",
+    "Eksternt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fra fil"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1.Skrive variabel til fil (id/kortnavn)\n",
+    "2. Redigerer Endre feltet status til valgt\n",
+    "3. Vardef.update_from file\n",
+    "Resultat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mulige feil"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Med kode\n",
+    "1.Lagre variabel i variabel (id/kortnavn)\n",
+    "2. Sette status\n",
+    "3. update draft\n",
+    "4. sjekk resultat"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dapla-toolbelt-metadata-fJc960va-py3.12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -26,8 +26,7 @@
     "\n",
     "Innhold:\n",
     "* [Oppsett](#oppsett)\n",
-    "* [Hente variabeldefinisjon](#hente-variabeldefinisjon)\n",
-    "* [Publiserer med kode](#kodebasert-metode-oppdatere-direkte-med-modeller)\n",
+    "* [Publiserer med kode](#Kodebasert-metode)\n",
     "* [Publisere med fil](#fil-basert-metode)"
    ]
   },

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -4,12 +4,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Publisere utkast\n",
+    "# Publisere et utkast\n",
+    "\n",
+    "Denne Notebook er for deg som:\n",
+    "\n",
+    "- Har en kvalitetsjekket variabeldefinisjon med status `UTKAST`\n",
+    "- Ønsker å publisere enten internt eller eksternt\n",
+    "\n",
+    "Forutsetninger:\n",
+    "- Du må ha enten `Kortnavn` eller `id` for variabeldefinisjonen\n",
+    "\n",
+    "Du kan velge to metoder:\n",
+    "- Fil-basert metode: Lag en YAML-fil og oppdater status med fil\n",
+    "- Kodebasert metode: Oppdater status direkte i kode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "Innhold:\n",
-    "* [Oppsett](#Oppsett)\n",
-    "* [Publisere fra fil](#Publisere-fra-fil)\n",
-    "* [Publiserer kode](#)\n"
+    "* [Oppsett](#oppsett)\n",
+    "* [Hente variabeldefinisjon](#hente-variabeldefinisjon)\n",
+    "* [Publiserer med kode](#kodebasert-metode-oppdatere-direkte-med-modeller)\n",
+    "* [Publisere med fil](#fil-basert-metode)"
    ]
   },
   {
@@ -50,43 +69,328 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Internt\n",
-    "Eksternt"
+    "## Kodebasert metode"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Fra fil"
+    "### Hente ut variabeldefinisjon ved hjelp av `Kortnavn` eller `id`"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "1.Skrive variabel til fil (id/kortnavn)\n",
-    "2. Redigerer Endre feltet status til valgt\n",
-    "3. Vardef.update_from file\n",
-    "Resultat"
+    "Hvis du har `Kortnavn` velg [Kortnavn](#kortnavn)\n",
+    "\n",
+    "Hvis du har `Id`  velg [Id](#id)\n",
+    "\n",
+    "NB! Velg kun en av metodene for å unngå feil.\n",
+    "\n",
+    "Gå deretter videre til [Endre status](#endre-status)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Mulige feil"
+    "#### Kortnavn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sett inn kortnavn mellom anførselstegn\n",
+    "mitt_kortnavn = \"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lagre variabeldefinisjonen i minnet\n",
+    "min_variabel = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Med kode\n",
-    "1.Lagre variabel i variabel (id/kortnavn)\n",
-    "2. Sette status\n",
-    "3. update draft\n",
-    "4. sjekk resultat"
+    "#### Id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sett inn id mellom anførselstegn\n",
+    "min_id = \"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lagre variabeldefinisjon i minnet med navnet '\n",
+    "min_variabel= Vardef.get_variable_definition_by_id(id=min_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Endre status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Publisere internt\n",
+    "min_variabel_status = models.VariableStatus.PUBLISHED_INTERNAL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "min_oppdatering = models.UpdateDraft(variable_status=min_variabel_status)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_variabel.update_draft(min_oppdatering)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Bekrefte publisering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Oppdater variabel\n",
+    "min_variabel = Vardef.get_variable_definition_by_shortname(mitt_kortnavn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(min_variabel.variable_status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fil-basert metode\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Skrive variabeldefinisjon til YAML-fil ved hjelp av kortnavn eller id\n",
+    "Du må velge mellom kortnavn eller id.\n",
+    "\n",
+    "Filnavn:\n",
+    "\n",
+    "Eksempel:\n",
+    "\n",
+    "Filen blir lagret på: \n",
+    "\n",
+    "Ønsker du å lagre filen på valgt område må du i tillegg til kortnavn eller id legge til en filsti for ønsket."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### YAML-fil med kortnavn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_variabel.to_file()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lagre i variabel?\n",
+    "#Vardef.get_variable_definition_by_shortname()\n",
+    "Vardef.write_variable_to_file(short_name=mitt_kortnavn)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### YAML-fil med ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var = Vardef.write_variable_to_file(id=min_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Velge hvor lagre"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Rediger YAML-fil\n",
+    "\n",
+    "1. Åpne YAML-fil med korrekt filnavn \n",
+    "2. Finn feltet `variabel_status`\n",
+    "3. Endre verdien til enten \"PUBLISHED_INTERNAL\" eller \"PUBLISHED_EXTERNAL\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Publisere variabeldefinisjonen\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_variabel.update_draft_from_file()\n",
+    "# Valgfri filsti?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hvis usikker på hvilken fil man skal redigerer\n",
+    "print(min_variabel.get_file_path())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Bekrefte publisering og sjekke status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Oppdater min_variabel kortnavn\n",
+    "# Her forsvinner file_path\n",
+    "min_variabel = Vardef.get_variable_definition_by_shortname(\"landbakk\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Oppdater min_variabel id\n",
+    "min_variabel = Vardef.get_variable_definition_by_shortname(\"landbakk\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#print(min_variabel.get_file_path())\n",
+    "# oppdater min_variabel \n",
+    "min_variabel = Vardef.get_variable_definition_by_shortname(\"landbakk2\")\n",
+    "print(min_variabel.variable_status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lagre endringer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Bekrefte publisering"
    ]
   }
  ],

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -9,14 +9,14 @@
     "Denne Notebook er for deg som:\n",
     "\n",
     "- Har en kvalitetsjekket variabeldefinisjon med status `UTKAST`\n",
-    "- Ønsker å publisere enten internt eller eksternt\n",
+    "- Ønsker å publisere internt\n",
     "\n",
     "Forutsetninger:\n",
-    "- Du må ha enten `Kortnavn` eller `id` for variabeldefinisjonen\n",
+    "- Du må ha enten `Kortnavn` eller `id` for variabeldefinisjonen du vil publisere\n",
     "\n",
     "Du kan velge to metoder:\n",
-    "- Fil-basert metode: Lag en YAML-fil og oppdater status med fil\n",
-    "- Kodebasert metode: Oppdater status direkte i kode"
+    "- Kodebasert metode: Oppdater status direkte i kode\n",
+    "- Fil-basert metode: Lag en YAML-fil og oppdater status med fil\n"
    ]
   },
   {
@@ -59,7 +59,7 @@
     "# Gjøre at logging vises\n",
     "logging.basicConfig(\n",
     "    format=\"%(levelname)s: %(message)s\",\n",
-    "    level=logging.INFO,\n",
+    "    level=logging.WARNING,\n",
     "    stream=sys.stdout,\n",
     "    force=True,\n",
     ")"
@@ -205,6 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Sjekk status\n",
     "print(min_variabel.variable_status)"
    ]
   },
@@ -220,16 +221,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Skrive variabeldefinisjon til YAML-fil ved hjelp av kortnavn eller id\n",
-    "Du må velge mellom kortnavn eller id.\n",
+    "### Skrive variabeldefinisjon til YAML-fil\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Hente ut variabeldefinisjon ved hjelp av `Kortnavn` eller `id`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hvis du har `Kortnavn` velg [Kortnavn](#kortnavn)\n",
     "\n",
-    "Filnavn:\n",
+    "Hvis du har `Id`  velg [Id](#id)\n",
     "\n",
-    "Eksempel:\n",
-    "\n",
-    "Filen blir lagret på: \n",
-    "\n",
-    "Ønsker du å lagre filen på valgt område må du i tillegg til kortnavn eller id legge til en filsti for ønsket."
+    "NB! Velg kun en av metodene for å unngå feil.\n"
    ]
   },
   {
@@ -245,7 +255,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "min_variabel.to_file()"
+    "# Sett inn kortnavn mellom anførselstegn\n",
+    "mitt_kortnavn_yaml = \"\"\n"
    ]
   },
   {
@@ -254,9 +265,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Lagre i variabel?\n",
-    "#Vardef.get_variable_definition_by_shortname()\n",
-    "Vardef.write_variable_to_file(short_name=mitt_kortnavn)"
+    "# Lagre variabeldefinisjonen i minnet\n",
+    "min_variabel_yaml = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn_yaml)"
    ]
   },
   {
@@ -271,7 +281,20 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Sett inn id mellom anførselstegn\n",
+    "min_id = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lagre variabeldefinisjon i minnet med navnet '\n",
+    "min_variabel_yaml= Vardef.get_variable_definition_by_id(id=min_id)"
+   ]
   },
   {
    "cell_type": "code",
@@ -286,7 +309,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Velge hvor lagre"
+    "### Skriv til fil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_variabel_yaml.to_file()"
    ]
   },
   {
@@ -297,36 +329,14 @@
     "\n",
     "1. Åpne YAML-fil med korrekt filnavn \n",
     "2. Finn feltet `variabel_status`\n",
-    "3. Endre verdien til enten \"PUBLISHED_INTERNAL\" eller \"PUBLISHED_EXTERNAL\""
+    "3. Endre verdien til enten `PUBLISHED_INTERNAL`"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "### Publisere variabeldefinisjonen\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "min_variabel.update_draft_from_file()\n",
-    "# Valgfri filsti?"
+    "### Lagre endringer"
    ]
   },
   {
@@ -335,8 +345,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Hvis usikker på hvilken fil man skal redigerer\n",
-    "print(min_variabel.get_file_path())"
+    "min_variabel_yaml.update_draft_from_file()"
    ]
   },
   {
@@ -352,9 +361,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Oppdater min_variabel kortnavn\n",
-    "# Her forsvinner file_path\n",
-    "min_variabel = Vardef.get_variable_definition_by_shortname(\"landbakk\")"
+    "\n",
+    "print(Vardef.get_variable_definition_by_shortname(mitt_kortnavn).variable_status)"
    ]
   },
   {
@@ -363,34 +371,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Oppdater min_variabel id\n",
-    "min_variabel = Vardef.get_variable_definition_by_shortname(\"landbakk\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#print(min_variabel.get_file_path())\n",
-    "# oppdater min_variabel \n",
-    "min_variabel = Vardef.get_variable_definition_by_shortname(\"landbakk2\")\n",
-    "print(min_variabel.variable_status)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Lagre endringer"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Bekrefte publisering"
+    "print(Vardef.get_variable_definition_by_id(min_id).variable_status)"
    ]
   }
  ],

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "Innhold:\n",
     "* [Oppsett](#oppsett)\n",
-    "* [Publiserer med kode](#Kodebasert-metode)\n",
+    "* [Publiserer med kode](#kodebasert-metode)\n",
     "* [Publisere med fil](#fil-basert-metode)"
    ]
   },
@@ -98,9 +98,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hvis du har `Kortnavn` velg [Variabeldefinisjon fra kortnavn](#Variabeldefinisjon-fra-kortnavn)\n",
+    "Hvis du har `Kortnavn` velg [Variabeldefinisjon fra kortnavn](#variabeldefinisjon-fra-kortnavn)\n",
     "\n",
-    "Hvis du har `id`  velg [Variabeldefinisjon fra id](#Variabeldefinisjon-fra-id)\n",
+    "Hvis du har `id`  velg [Variabeldefinisjon fra id](#variabeldefinisjon-fra-id)\n",
     "\n",
     "NB! Velg kun en av metodene for å unngå feil.\n",
     "\n",
@@ -257,13 +257,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hvis du har `Kortnavn` velg [YAML-fil med kortnavn](#YAML-fil-med-kortnavn)\n",
+    "Hvis du har `Kortnavn` velg [YAML-fil med kortnavn](#yaml-fil-med-kortnavn)\n",
     "\n",
-    "Hvis du har `id`  velg [YAML-fil med id](#YAML-fil-med-id)\n",
+    "Hvis du har `id`  velg [YAML-fil med id](#yaml-fil-med-id)\n",
     "\n",
     "NB! Velg kun en av metodene for å unngå feil.\n",
     "\n",
-    "Gå deretter videre til [Skriv til fil](#Skriv-til-fil)\n"
+    "Gå deretter videre til [Skriv til fil](#skriv-til-fil)\n"
    ]
   },
   {

--- a/demo/variable_definitions/publisere_utkast.ipynb
+++ b/demo/variable_definitions/publisere_utkast.ipynb
@@ -186,7 +186,7 @@
    "outputs": [],
    "source": [
     "# Bytt ut None med status\n",
-    "min_status = status_internt\n",
+    "min_status = None\n",
     "min_oppdatering = models.UpdateDraft(variable_status=min_status)"
    ]
   },


### PR DESCRIPTION
This notebook demonstrates two methods for publishing a variable definition from draft
- Code based method
- File based method

Code based method is definitely the easiest (not so many possibilities for errors) when only updating one field so this chapter is placed before file based method.

Allow some duplication for minimizing user errors:
- getting variable definition for each method

Use variables to support user, but try to avoid errors caused by running cells by accident for example like this:

![Screenshot 2025-03-07 at 10 57 29](https://github.com/user-attachments/assets/c636b132-70f9-4634-ac9d-9cb8c3b26e7e)


Add index at top with links:
- doesn't always work, but it should in theory. 
- Errors probably caused by caching/metadata saved in notebooks
- Are still useful for navigation (are highlighted anyway)

No custom directory for saving file since it is not implemented yet for method


