### PR TITLE
add method check if short name exists

### DIFF
--- a/src/dapla_metadata/variable_definitions/vardef.py
+++ b/src/dapla_metadata/variable_definitions/vardef.py
@@ -273,3 +273,19 @@ class Vardef:
             f"Created editable variable definition template file at {file_path}",  # noqa: G004
         )
         return file_path
+
+    @classmethod
+    @vardef_exception_handler
+    def does_short_name_exist(
+        cls,
+        short_name: str,
+    ) -> bool:
+        """Return True if the short name exists in Vardef, otherwise False."""
+        variable_definitions = Vardef.list_variable_definitions()
+        for variable in variable_definitions:
+            if short_name == variable.short_name:
+                logger.info(
+                    f"Found duplicate short name {short_name}",  # noqa: G004
+                )
+                return True
+        return False

--- a/tests/variable_definitions/test_vardef.py
+++ b/tests/variable_definitions/test_vardef.py
@@ -2,6 +2,7 @@ import functools
 from collections.abc import Callable
 from http import HTTPStatus
 from pathlib import Path
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -211,3 +212,38 @@ def test_migrate_from_vardok(
     assert my_draft.id is not None
     assert my_draft.patch_id == 1
     assert my_draft.variable_status == VariableStatus.DRAFT
+
+
+def test_short_name_exist():
+    mock_variable = MagicMock()
+    mock_variable.short_name = "test_name"
+
+    mock_variable1 = MagicMock()
+    mock_variable1.short_name = "random_name"
+
+    mock_variable2 = MagicMock()
+    mock_variable2.short_name = "pluu_h"
+
+    mock_variable3 = MagicMock()
+    mock_variable3.short_name = "another_name"
+
+    with patch(
+        "dapla_metadata.variable_definitions.vardef.Vardef.list_variable_definitions",
+        return_value=[mock_variable, mock_variable1, mock_variable2, mock_variable3],
+    ):
+        result = Vardef.does_short_name_exist("test_name")
+        assert result is True
+
+
+def test_short_name_does_not_exist():
+    mock_variable = MagicMock()
+    mock_variable.short_name = "test_name"
+
+    mock_variable1 = MagicMock()
+    mock_variable1.short_name = "random_name"
+    with patch(
+        "dapla_metadata.variable_definitions.vardef.Vardef.list_variable_definitions",
+        return_value=[mock_variable, mock_variable1],
+    ):
+        result = Vardef.does_short_name_exist("org_name")
+        assert result is False


### PR DESCRIPTION
There has been mentioned the need for checking if a short name already exists when owners discussing/decide short names. Especially when migrating from Vardok.