### PR TITLE
strip input

### DIFF
--- a/src/dapla_metadata/variable_definitions/vardef.py
+++ b/src/dapla_metadata/variable_definitions/vardef.py
@@ -283,7 +283,7 @@ class Vardef:
         """Return True if the short name exists in Vardef, otherwise False."""
         variable_definitions = Vardef.list_variable_definitions()
         for variable in variable_definitions:
-            if short_name == variable.short_name:
+            if short_name.strip() == variable.short_name:
                 logger.info(
                     f"Found duplicate short name {short_name}",  # noqa: G004
                 )

--- a/tests/variable_definitions/test_vardef.py
+++ b/tests/variable_definitions/test_vardef.py
@@ -247,3 +247,17 @@ def test_short_name_does_not_exist():
     ):
         result = Vardef.does_short_name_exist("org_name")
         assert result is False
+
+
+def test_short_name_with_whitespace():
+    mock_variable = MagicMock()
+    mock_variable.short_name = "test_name"
+
+    mock_variable1 = MagicMock()
+    mock_variable1.short_name = "random_name"
+    with patch(
+        "dapla_metadata.variable_definitions.vardef.Vardef.list_variable_definitions",
+        return_value=[mock_variable, mock_variable1],
+    ):
+        result = Vardef.does_short_name_exist("test_name  ")
+        assert result is True


### PR DESCRIPTION
When checking short name unintentional whitespace should be ignored