### PR TITLE
add exclusion for generated files sonar cloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,3 +9,5 @@ sonar.python.version=3.11
 sonar.python.coverage.reportPaths=coverage.xml
 
 sonar.sourceEncoding=UTF-8
+
+sonar.exclusions=**/dapla_metadata/variable_definitions/_generated/**


### PR DESCRIPTION
This was set under settings Sonar cloud, but was broken when file paths changed

Add to file because it is easier to keep up with changes from the code

There are three possible settings (sonar.coverage.exclusions, sonar.cpd.exclusions and sonar.exclusions)

sonar.exclusions should exclude generated files both from code coverage and duplication