### PR TITLE
Fixing bug causing file path to be lost

### DIFF
--- a/demo/variable_definitions/redigere_utkast.ipynb
+++ b/demo/variable_definitions/redigere_utkast.ipynb
@@ -106,7 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "min_variabel = min_variabel.update_draft_from_file()"
+    "min_variabel.update_draft_from_file()"
    ]
   }
  ],


### PR DESCRIPTION
Fixing so that a variable definition with status draft can be updated from the same file more than once