### PR TITLE
Validate partitioned dataset paths

### DIFF
--- a/src/dapla_metadata/datasets/dapla_dataset_path_info.py
+++ b/src/dapla_metadata/datasets/dapla_dataset_path_info.py
@@ -340,6 +340,16 @@ class DaplaDatasetPathInfo:
         self.dataset_path = pathlib.Path(dataset_path)
         self.dataset_name_sections = self.dataset_path.stem.split("_")
         self._period_strings = self._extract_period_strings(self.dataset_name_sections)
+        self.is_partitioned_data = self._is_partitioned_data()
+
+    def _is_partitioned_data(self):
+        """Check if dataset path is partitioned data."""
+        for part in self.dataset_path.parts:
+            if "=" in part:
+                key, value = part.split("=", 1)
+                if key and value:
+                    return True
+        return False
 
     @staticmethod
     def _get_period_string_indices(dataset_name_sections: list[str]) -> list[int]:

--- a/src/dapla_metadata/datasets/dapla_dataset_path_info.py
+++ b/src/dapla_metadata/datasets/dapla_dataset_path_info.py
@@ -352,6 +352,10 @@ class DaplaDatasetPathInfo:
         Examples:
             >>> DaplaDatasetPathInfo("gs://team-bøtte/statistikk/klargjorte-data/persondata_p1990-Q1_p2023-Q4_v1/aar=2018").is_partitioned_data
             True
+
+            >>> DaplaDatasetPathInfo("team-bøtte/stat/inndata/person_p1990-Q1_p2023-Q4_v1/aar=2019/data.parquet").is_partitioned_data
+            True
+
             >>> DaplaDatasetPathInfo("gs://team-bøtte/statistikk/klargjorte-data/persondata_p1990-Q1_p2023-Q4_v1.parquet").is_partitioned_data
             False
         """

--- a/src/dapla_metadata/datasets/dapla_dataset_path_info.py
+++ b/src/dapla_metadata/datasets/dapla_dataset_path_info.py
@@ -338,12 +338,23 @@ class DaplaDatasetPathInfo:
         """Digest the path so that it's ready for further parsing."""
         self.dataset_string = str(dataset_path)
         self.dataset_path = pathlib.Path(dataset_path)
-        self.dataset_name_sections = self.dataset_path.stem.split("_")
-        self._period_strings = self._extract_period_strings(self.dataset_name_sections)
         self.is_partitioned_data = self._is_partitioned_data()
+        self.dataset_name_sections = (
+            self.dataset_path.parts[-3].split("_")
+            if self.is_partitioned_data
+            else self.dataset_path.stem.split("_")
+        )
+        self._period_strings = self._extract_period_strings(self.dataset_name_sections)
 
     def _is_partitioned_data(self):
-        """Check if dataset path is partitioned data."""
+        """Check if dataset path is partitioned data.
+
+        Examples:
+            >>> DaplaDatasetPathInfo("gs://team-bøtte/statistikk/klargjorte-data/persondata_p1990-Q1_p2023-Q4_v1/aar=2018").is_partitioned_data
+            True
+            >>> DaplaDatasetPathInfo("gs://team-bøtte/statistikk/klargjorte-data/persondata_p1990-Q1_p2023-Q4_v1.parquet").is_partitioned_data
+            False
+        """
         for part in self.dataset_path.parts:
             if "=" in part:
                 key, value = part.split("=", 1)

--- a/src/dapla_metadata/datasets/dapla_dataset_path_info.py
+++ b/src/dapla_metadata/datasets/dapla_dataset_path_info.py
@@ -761,6 +761,12 @@ class DaplaDatasetPathInfo:
 
             >>> DaplaDatasetPathInfo('resources/buckets/produkt/befolkning/utdata/person_data.parquet').statistic_short_name
             befolkning
+
+            >>> DaplaDatasetPathInfo('gs://statistikk/produkt/klargjorte-data/persondata_p1990-Q1_p2023-Q4_v1/aar=2019/data.parquet').statistic_short_name
+            produkt
+
+            >>> DaplaDatasetPathInfo('gs://statistikk/produkt/persondata_p1990-Q1_p2023-Q4_v1/aar=2019/data.parquet').statistic_short_name
+            None
         """
         dataset_state = self.dataset_state
         # Not possible to retrieve short name when dataset state folder is not present

--- a/src/dapla_metadata/standards/name_validator.py
+++ b/src/dapla_metadata/standards/name_validator.py
@@ -63,12 +63,8 @@ class PartitionedDataValidator:
 
     def __init__(
         self,
-        file_path: Path | str,
     ) -> None:
         """Initialize the validator."""
-        self.file_path = file_path
-        self.path_info = DaplaDatasetPathInfo(self.file_path)
-        self.result = ValidationResult()
 
     @staticmethod
     def is_invalid_symbols(s: str) -> bool:

--- a/src/dapla_metadata/standards/name_validator.py
+++ b/src/dapla_metadata/standards/name_validator.py
@@ -24,7 +24,7 @@ class ValidationResult:
         self,
         success: bool = True,
     ) -> None:
-        """Initialize the validatation result."""
+        """Initialize the validation result."""
         self.success: bool = success
         self.file_path: str | None = None
         self.messages: list[str] = []
@@ -54,6 +54,40 @@ class ValidationResult:
             "messages": self.messages,
             "violations": self.violations,
         }
+
+
+class PartitionedDataValidator:
+    """Validator for ensuring partioned data files adhere to naming standard."""
+
+    INVALID_PATTERN = r"[^a-zA-Z0-9\./:_=-]"
+
+    def __init__(
+        self,
+        file_path: Path | str,
+    ) -> None:
+        """Initialize the validator."""
+        self.file_path = file_path
+        self.path_info = DaplaDatasetPathInfo(self.file_path)
+        self.result = ValidationResult()
+
+    @staticmethod
+    def is_invalid_symbols(s: str) -> bool:
+        """Return True if string contains illegal symbols.
+
+        Examples:
+            >>> PartitionedDataValidator.is_invalid_symbols("åregang-øre")
+            True
+
+            >>> PartitionedDataValidator.is_invalid_symbols("Azor89=value")
+            False
+
+            >>> PartitionedDataValidator.is_invalid_symbols("ssbÆ-dapla-example-data-produkt-prod/ledstill/oppdrag/skjema_p2018_p2020_v1")
+            True
+
+            >>> PartitionedDataValidator.is_invalid_symbols("ssb-dapla-example-data-produkt-prod/ledstill/oppdrag/skjema_p2018_p2020_v1")
+            False
+        """
+        return bool(re.search(PartitionedDataValidator.INVALID_PATTERN, s.strip()))
 
 
 class NameStandardValidator:

--- a/src/dapla_metadata/standards/name_validator.py
+++ b/src/dapla_metadata/standards/name_validator.py
@@ -174,10 +174,10 @@ class NameStandardValidator:
         }
 
         violations = [message for message, value in checks.items() if not value]
-        if self.path_info.is_partitioned_data:
+        if self.file_path and self.path_info.is_partitioned_data:
             if PartitionedDataValidator.is_invalid_symbols(self.file_path.as_posix()):
                 violations.append(INVALID_SYMBOLS)
-        elif self.is_invalid_symbols(self.file_path.as_posix()):
+        elif self.file_path and self.is_invalid_symbols(self.file_path.as_posix()):
             violations.append(INVALID_SYMBOLS)
 
         for violation in violations:

--- a/src/dapla_metadata/standards/name_validator.py
+++ b/src/dapla_metadata/standards/name_validator.py
@@ -174,10 +174,10 @@ class NameStandardValidator:
         }
 
         violations = [message for message, value in checks.items() if not value]
-
-        if self.file_path is not None and self.is_invalid_symbols(
-            self.file_path.as_posix(),
-        ):
+        if self.path_info.is_partitioned_data:
+            if PartitionedDataValidator.is_invalid_symbols(self.file_path.as_posix()):
+                violations.append(INVALID_SYMBOLS)
+        elif self.is_invalid_symbols(self.file_path.as_posix()):
             violations.append(INVALID_SYMBOLS)
 
         for violation in violations:

--- a/src/dapla_metadata/standards/standard_validators.py
+++ b/src/dapla_metadata/standards/standard_validators.py
@@ -27,7 +27,13 @@ def check_naming_standard(
         >>> check_naming_standard(file_path=Path("/data/example_file.parquet")).success
         False
 
+        >>> check_naming_standard(file_path=Path("ssb-dapla-example-data-produkt-prod/ledstill/inndata/skjema_v1/aar=2018/data.parquet")).success
+        False
+
         >>> check_naming_standard(file_path=Path("buckets/produkt/datadoc/utdata/person_data_p2021_v2.parquet")).success
+        True
+
+        >>> check_naming_standard(file_path=Path("ssb-dapla-example-data-produkt-prod/ledstill/inndata/skjema_p2018_p2020_v1/aar=2018/data.parquet")).success
         True
     """
     naming_validator = NameStandardValidator(

--- a/src/dapla_metadata/standards/utils/constants.py
+++ b/src/dapla_metadata/standards/utils/constants.py
@@ -6,7 +6,7 @@ NAME_STANDARD_SUCSESS = "Filene dine er i samsvar med SSB-navnestandarden"
 
 NAME_STANDARD_VIOLATION = "Det er oppdaget brudd på SSB-navnestandard:"
 
-MISSING_BUCKET_NAME = "Filnavn mangler bøttenavn ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#obligatoriske-mapper"
+MISSING_BUCKET_NAME = "Filsti mangler bøtte ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#obligatoriske-mapper"
 MISSING_VERSION = "Filnavn mangler versjon ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#filnavn"
 MISSING_PERIOD = "Filnavn mangler gyldighetsperiode ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#filnavn"
 MISSING_SHORT_NAME = "Kortnavn for statistikk mangler ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#obligatoriske-mapper"

--- a/tests/standards/test_name_validator.py
+++ b/tests/standards/test_name_validator.py
@@ -170,10 +170,10 @@ def test_bucket_validation_partitioned_data_success(
     (processed_path / processed_file_paths[0]).touch()
     (processed_path / processed_file_paths[1]).touch()
 
-    validator = NameStandardValidator(file_path=None, bucket_name=bucket_name)
+    validator = BucketNameValidator(bucket_name=bucket_name)
     monkeypatch.setattr(validator, "bucket_directory", fake_bucket)
 
-    results = validator.validate_bucket()
+    results = validator.validate()
 
     assert len(results) == 4
     assert all(result.success for result in results)
@@ -232,10 +232,10 @@ def test_bucket_validation_partitioned_data_violations(
     (processed_path / processed_file_paths[0]).touch()
     (processed_path / processed_file_paths[1]).touch()
 
-    validator = NameStandardValidator(file_path=None, bucket_name=bucket_name)
+    validator = BucketNameValidator(bucket_name=bucket_name)
     monkeypatch.setattr(validator, "bucket_directory", fake_bucket)
 
-    results = validator.validate_bucket()
+    results = validator.validate()
 
     assert len(results) == 4
     assert all(not result.success for result in results)

--- a/tests/standards/test_name_validator.py
+++ b/tests/standards/test_name_validator.py
@@ -172,3 +172,66 @@ def test_bucket_validation_partitioned_data_success(
     assert len(results) == 4
     assert all(result.success for result in results)
     assert all(NAME_STANDARD_SUCSESS in result.messages for result in results)
+
+
+@pytest.mark.parametrize(
+    ("short_name", "indata_file_paths", "processed_file_paths", "bucket_name"),
+    [
+        (
+            "stat_reg",
+            [
+                "person_data_v2/year=2017/data.parquet",
+                "_p2017_p2024_v2/year=2018/data.parquet",
+            ],
+            [
+                "_p2017_p2024_v2/year=2017/edited.parquet",
+                "person_data_v2/year=2018/edited.parquet",
+            ],
+            "ssb-staging-dapla-felles-data-delt",
+        ),
+    ],
+)
+def test_bucket_validation_partitioned_data_violations(
+    short_name,
+    indata_file_paths,
+    processed_file_paths,
+    bucket_name,
+    monkeypatch,
+    tmp_path,
+):
+    fake_bucket = tmp_path / bucket_name / short_name
+
+    fake_bucket.mkdir(parents=True, exist_ok=True)
+    indata_path = fake_bucket / "inndata"
+    processed_path = fake_bucket / "klargjorte_data"
+
+    indata_path.mkdir(parents=True, exist_ok=True)
+    processed_path.mkdir(parents=True, exist_ok=True)
+
+    (indata_path / Path(indata_file_paths[0]).parent).mkdir(parents=True, exist_ok=True)
+    (indata_path / Path(indata_file_paths[1]).parent).mkdir(parents=True, exist_ok=True)
+
+    (processed_path / Path(processed_file_paths[0]).parent).mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    (processed_path / Path(processed_file_paths[1]).parent).mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    (indata_path / indata_file_paths[0]).touch()
+    (indata_path / indata_file_paths[1]).touch()
+
+    (processed_path / processed_file_paths[0]).touch()
+    (processed_path / processed_file_paths[1]).touch()
+
+    validator = NameStandardValidator(file_path=None, bucket_name=bucket_name)
+    monkeypatch.setattr(validator, "bucket_directory", fake_bucket)
+
+    results = validator.validate_bucket()
+
+    assert len(results) == 4
+    assert all(not result.success for result in results)
+    assert any(MISSING_PERIOD in result.violations for result in results)
+    assert any(MISSING_DATASET_SHORT_NAME in result.violations for result in results)

--- a/tests/standards/test_standards.py
+++ b/tests/standards/test_standards.py
@@ -235,12 +235,8 @@ def test_valid_partioned_path_success(file_path, tmp_path):
     ("file_path", "violations"),
     [
         (
-            "ssb-dapla-example-data-produkt-prod/inndata/skjema_p2018_p202_v1/aar=2018/data.parquet",
-            [MISSING_PERIOD],
-        ),
-        (
             "buckets/ssb-dapla-example-data-produkt-prod/ledstill/skjema_p2018_p202_v1/aar=2019/data.parquet",
-            [MISSING_SHORT_NAME, MISSING_DATA_STATE, MISSING_PERIOD],
+            [MISSING_SHORT_NAME, MISSING_DATA_STATE],
         ),
         (
             "ssb-dapla-example-data-produkt-prod/ledstill/klargjorte_data/editert_v1/aar=2018/data.parquet",

--- a/tests/standards/test_standards.py
+++ b/tests/standards/test_standards.py
@@ -246,11 +246,42 @@ def test_partioned_path_success(file_path, tmp_path):
             "buckets/ssb-dapla-example-data-produkt-prod/inndata/skjema_p2018_p202_v1/aar=2018/data.parquet",
             MISSING_SHORT_NAME,
         ),
+        (
+            "ssb-dapla-example-data-produkt-prod/ledstill/klargjorte_data/_p2018_p202_v1/aar=2018/data.parquet",
+            MISSING_DATASET_SHORT_NAME,
+        ),
     ],
 )
-def test_valid_partioned_path_violations(file_path, violation, tmp_path):
+def test_partioned_path_violations(file_path, violation, tmp_path):
     full_path = tmp_path / file_path
     full_path.parent.mkdir(parents=True, exist_ok=True)
     full_path.touch()
     result = check_naming_standard(file_path=full_path)
     assert violation in result.violations
+
+
+def test_partioned_path_path_ignored(tmp_path):
+    file_path = "ssb-dapla-example-data-produkt-prod/tidsserier/inndata/skjema_p2018_p202_v1/aar=2018/data.parquet"
+    full_path = tmp_path / file_path
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.touch()
+    result = check_naming_standard(file_path=full_path)
+    assert PATH_IGNORED in result.messages
+    assert result.success
+    assert len(result.violations) == 0
+
+
+def test_partioned_path_not_confirmed_success():
+    file_path = "ssb-dapla-example-data-produkt-prod/ledstill/inndata/skjema_p2018_p202_v1/aar=2018/data.parquet"
+    result = check_naming_standard(file_path=file_path)
+    assert FILE_PATH_NOT_CONFIRMED in result.messages
+    assert result.success
+    assert NAME_STANDARD_SUCSESS in result.messages
+
+
+def test_partioned_path_not_confirmed_violation():
+    file_path = "ssb-dapla-example-data-produkt-prod/ledstill/inndata/skjema_v1/aar=2018/data.parquet"
+    result = check_naming_standard(file_path=file_path)
+    assert FILE_PATH_NOT_CONFIRMED in result.messages
+    assert not result.success
+    assert MISSING_PERIOD in result.violations

--- a/tests/standards/test_standards.py
+++ b/tests/standards/test_standards.py
@@ -222,7 +222,7 @@ def test_missing_multiple(file_path: str, violations: list, tmp_path):
         "ssb-dapla-example-data-produkt-prod/ledstill/klargjorte_data/editert_p2018_p202_v1/aar=2018/data.parquet",
     ],
 )
-def test_valid_partioned_path_success(file_path, tmp_path):
+def test_partioned_path_success(file_path, tmp_path):
     full_path = tmp_path / file_path
     full_path.parent.mkdir(parents=True, exist_ok=True)
     full_path.touch()
@@ -232,21 +232,25 @@ def test_valid_partioned_path_success(file_path, tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("file_path", "violations"),
+    ("file_path", "violation"),
     [
         (
             "buckets/ssb-dapla-example-data-produkt-prod/ledstill/skjema_p2018_p202_v1/aar=2019/data.parquet",
-            [MISSING_SHORT_NAME, MISSING_DATA_STATE],
+            MISSING_DATA_STATE,
         ),
         (
             "ssb-dapla-example-data-produkt-prod/ledstill/klargjorte_data/editert_v1/aar=2018/data.parquet",
-            [MISSING_PERIOD],
+            MISSING_PERIOD,
+        ),
+        (
+            "buckets/ssb-dapla-example-data-produkt-prod/inndata/skjema_p2018_p202_v1/aar=2018/data.parquet",
+            MISSING_SHORT_NAME,
         ),
     ],
 )
-def test_valid_partioned_path_violations(file_path, violations, tmp_path):
+def test_valid_partioned_path_violations(file_path, violation, tmp_path):
     full_path = tmp_path / file_path
     full_path.parent.mkdir(parents=True, exist_ok=True)
     full_path.touch()
     result = check_naming_standard(file_path=full_path)
-    assert result.violations == violations
+    assert violation in result.violations

--- a/tests/standards/test_standards.py
+++ b/tests/standards/test_standards.py
@@ -227,9 +227,7 @@ def test_valid_partioned_path_success(file_path, tmp_path):
     full_path.parent.mkdir(parents=True, exist_ok=True)
     full_path.touch()
     result = check_naming_standard(file_path=full_path)
-    assert result.messages == [
-        NAME_STANDARD_SUCSESS,
-    ]
+    assert NAME_STANDARD_SUCSESS in result.messages
     assert isinstance(result, ValidationResult)
 
 

--- a/tests/standards/test_standards.py
+++ b/tests/standards/test_standards.py
@@ -238,15 +238,15 @@ def test_valid_partioned_path_success(file_path, tmp_path):
     [
         (
             "ssb-dapla-example-data-produkt-prod/inndata/skjema_p2018_p202_v1/aar=2018/data.parquet",
-            [MISSING_PERIOD, INVALID_SYMBOLS],
+            [MISSING_PERIOD],
         ),
         (
             "buckets/ssb-dapla-example-data-produkt-prod/ledstill/skjema_p2018_p202_v1/aar=2019/data.parquet",
-            [MISSING_SHORT_NAME, MISSING_DATA_STATE, MISSING_PERIOD, INVALID_SYMBOLS],
+            [MISSING_SHORT_NAME, MISSING_DATA_STATE, MISSING_PERIOD],
         ),
         (
             "ssb-dapla-example-data-produkt-prod/ledstill/klargjorte_data/editert_v1/aar=2018/data.parquet",
-            [MISSING_PERIOD, INVALID_SYMBOLS],
+            [MISSING_PERIOD],
         ),
     ],
 )

--- a/tests/standards/test_standards.py
+++ b/tests/standards/test_standards.py
@@ -212,3 +212,47 @@ def test_missing_multiple(file_path: str, violations: list, tmp_path):
     result = check_naming_standard(file_path=full_path)
     if isinstance(result, ValidationResult):
         assert any(v for v in result.violations for v in violations)
+
+
+@pytest.mark.parametrize(
+    ("file_path"),
+    [
+        "ssb-dapla-example-data-produkt-prod/ledstill/inndata/skjema_p2018_p202_v1/aar=2018/data.parquet",
+        "buckets/ssb-dapla-example-data-produkt-prod/ledstill/inndata/skjema_p2018_p202_v1/aar=2019/data.parquet",
+        "ssb-dapla-example-data-produkt-prod/ledstill/klargjorte_data/editert_p2018_p202_v1/aar=2018/data.parquet",
+    ],
+)
+def test_valid_partioned_path_success(file_path, tmp_path):
+    full_path = tmp_path / file_path
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.touch()
+    result = check_naming_standard(file_path=full_path)
+    assert result.messages == [
+        NAME_STANDARD_SUCSESS,
+    ]
+    assert isinstance(result, ValidationResult)
+
+
+@pytest.mark.parametrize(
+    ("file_path", "violations"),
+    [
+        (
+            "ssb-dapla-example-data-produkt-prod/inndata/skjema_p2018_p202_v1/aar=2018/data.parquet",
+            [MISSING_PERIOD, INVALID_SYMBOLS],
+        ),
+        (
+            "buckets/ssb-dapla-example-data-produkt-prod/ledstill/skjema_p2018_p202_v1/aar=2019/data.parquet",
+            [MISSING_SHORT_NAME, MISSING_DATA_STATE, MISSING_PERIOD, INVALID_SYMBOLS],
+        ),
+        (
+            "ssb-dapla-example-data-produkt-prod/ledstill/klargjorte_data/editert_v1/aar=2018/data.parquet",
+            [MISSING_PERIOD, INVALID_SYMBOLS],
+        ),
+    ],
+)
+def test_valid_partioned_path_violations(file_path, violations, tmp_path):
+    full_path = tmp_path / file_path
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.touch()
+    result = check_naming_standard(file_path=full_path)
+    assert result.violations == violations


### PR DESCRIPTION
Assuming https://manual.dapla.ssb.no/statistikkere/navnestandard.html#partisjonerte-data is correct:
- Trim the file path for key/value parts and the file suffix part in `DaplaDatasetPathInfo` 
- Valid symbol is now also "="
- Separate class for `PartitionedDataValidator`, but for now it is only check for invalid symbols which differ from other validations. But it could maybe be other unique partitioned file path checks

