### PR TITLE
json-schema for variable definition yaml files

### DIFF
--- a/schemas/jsonschema/complete-response-schema.json
+++ b/schemas/jsonschema/complete-response-schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://ssb.no/schemas/dapla/metadata/variable-definitions/complete-response",
+  "type": "object",
+  "title": "CompleteResponse",
+  "additionalProperties": false,
+  "required": [
+    "contact",
+    "contains_special_categories_of_personal_data",
+    "created_at",
+    "created_by",
+    "definition",
+    "id",
+    "last_updated_at",
+    "last_updated_by",
+    "name",
+    "owner",
+    "patch_id",
+    "short_name",
+    "subject_fields",
+    "unit_types",
+    "valid_from"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unik SSB identifikator for variabeldefinisjonen. Denne blir maskingenerert.\nVariabeldefinisjoner med ulike gyldighetsperioder har samme ID og samme kortnavn.",
+      "pattern": "^[a-zA-Z0-9-_]{8}$",
+      "examples": ["qSDlxNVO"]
+    },
+    "patch_id": {
+      "type": "integer",
+      "description": "Løpenummer som identifiserer en patch, endring, for en variabeldefinisjon.",
+      "format": "int32",
+      "examples": [1]
+    },
+    "name": {
+      "description": "Variabelens navn. Dette skal ikke være en mer “teknisk” forkortelse, men et navn som er forståelig for mennesker.",
+      "$ref": "#/$defs/LanguageStringType",
+      "examples": [
+        { "nb": "Sivilstand", "nn": "Sivilstand", "en": "Marital status" }
+      ]
+    },
+    "short_name": {
+      "type": "string",
+      "description": "Dette er variabelens kortnavn, som kan være en mer “teknisk” forkortelse, f.eks. wlonn (kortnavnet til Lønnsinntekter). Kortnavnet til en variabel i Vardef skal være unikt.\nKravet til kortnavnet er at det kan inneholde a-z (kun små bokstaver), 0-9 og _ (understrek). Minimumslengden på kortnavnet er 2 tegn.  Bokstavene 'æ', 'ø' og 'å' kan ikke brukes. Disse anbefales erstattet med hhv. 'ae', 'oe' og 'aa'",
+      "pattern": "^[a-z0-9_]{2,}$",
+      "examples": ["sivilstand", "wlonn"]
+    },
+    "definition": {
+      "description": "En definisjon skal beskrive hva variabelen betyr og være så kort og presis som mulig. Mer utfyllende opplysninger kan legges i Merknad-feltet.",
+      "$ref": "#/$defs/LanguageStringType",
+      "examples": [
+        {
+          "nb": "Variabelen viser en persons stilling i forhold til ekteskapslovgivningen",
+          "nn": "Variabelen viser tilstand ein person er i, sett i høve til ekteskapslovgivinga",
+          "en": "This variable shows the person's marital status according to marital legislation."
+        }
+      ]
+    },
+    "classification_reference": {
+      "type": ["string", "null"],
+      "description": "ID av en klassifikasjon eller kodeliste fra KLASS som beskriver verdiene variabelen kan anta.\nFor eksempel vil variabelen 'Sivilstand' ha klassifikasjon 'Standard for sivilstand' (kan vises på https://www.ssb.no/klass/klassifikasjoner/19 ) som har ID 19.",
+      "pattern": "^[0-9]+$",
+      "nullable": true,
+      "examples": ["19"]
+    },
+    "unit_types": {
+      "type": "array",
+      "description": "Enhetstyper - enhetene som beskrives av denne variabelen. Variabelen “sivilstand” vil f.eks. ha enhetstypen person, mens f.eks. “Produsentpris for tjenester” vil ha både foretak og bedrift som enhetstyper siden variabelen kan beskrive begge.\nVerdier skal være koder fra: https://www.ssb.no/klass/klassifikasjoner/702.",
+      "items": {
+        "type": "string"
+      },
+      "examples": [["12", "13"]]
+    },
+    "subject_fields": {
+      "type": "array",
+      "description": "Statistikkområder som variabelen brukes innenfor. For eksempel tilhører variabelen “Sivilstand” statistikkområdet “Befolkning”.\nVerdier skal være koder fra https://www.ssb.no/klass/klassifikasjoner/618.",
+      "items": {
+        "type": "string"
+      },
+      "examples": [["al"]]
+    },
+    "contains_special_categories_of_personal_data": {
+      "type": "boolean",
+      "description": "Viser om variabelen inneholder spesielt sensitive personopplysninger.\nKategorier:\n- opplysninger om etnisk opprinnelse\n- opplysninger om politisk oppfatning\n- opplysninger om religion\n- opplysninger om filosofisk overbevisning\n- opplysninger om fagforeningsmedlemskap\n- genetiske opplysninger\n- biometriske opplysninger med det formål å entydig identifisere noen\n- helseopplysninger\n- opplysninger om seksuelle forhold\n- opplysninger om seksuell legning\nref: https://lovdata.no/dokument/NL/lov/2018-06-15-38/KAPITTEL_gdpr-2#gdpr/a9",
+      "examples": [false]
+    },
+    "variable_status": {
+      "description": "Livssyklus for variabelen.",
+      "nullable": true,
+      "$ref": "#/$defs/VariableStatus",
+      "examples": ["PUBLISHED_EXTERNAL"]
+    },
+    "measurement_type": {
+      "type": ["string", "null"],
+      "description": "Måletype som en kvantitativ variabelen tilhører, f.eks.  valuta, areal osv.\nVerdien skal være en kode fra: https://www.ssb.no/klass/klassifikasjoner/303",
+      "nullable": true,
+      "examples": ["03"]
+    },
+    "valid_from": {
+      "type": "string",
+      "description": "Datoen variabeldefinisjonen er gyldig f.o.m.",
+      "format": "date",
+      "examples": ["1990-01-01"]
+    },
+    "valid_until": {
+      "type": ["string", "null"],
+      "description": "Datoen variabeldefinisjonens var gyldig t.o.m. Settes hvis definisjonen skal erstattet av en ny definisjon (med en ny gyldighetsperiode), eller variabelen ikke lenger skal brukes.",
+      "format": "date",
+      "nullable": true,
+      "examples": ["2000-01-01"]
+    },
+    "external_reference_uri": {
+      "type": ["string", "null"],
+      "description": "En peker (URI) til ekstern definisjon/dokumentasjon, f.eks. ei webside som er relevant for variabelen.",
+      "format": "url",
+      "nullable": true,
+      "examples": ["https://www.example.com"]
+    },
+    "comment": {
+      "description": "Her kan en sette inn eventuelle tilleggsopplysninger som ikke hører hjemme i selve definisjonen. Variabelen “Landbakgrunn” har f.eks. merknaden “Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland”.",
+      "nullable": true,
+      "oneOf": [{ "$ref": "#/$defs/LanguageStringType" }, { "type": "null" }],
+      "examples": [
+        {
+          "nb": "Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland",
+          "nn": null,
+          "en": null
+        }
+      ]
+    },
+    "related_variable_definition_uris": {
+      "type": "array",
+      "description": "Her kan en legge inn URIer til andre variabler som er relevante. Eksempelvis er variabelen “Inntekt etter skatt” en beregnet variabel der “Yrkesinntekter” og “Kapitalinntekter” inngår i beregningen. En kan da legge inn deres URI-er i dette feltet.",
+      "nullable": true,
+      "items": {
+        "type": "string",
+        "format": "url"
+      },
+      "examples": [
+        ["https://www.ssb.no/a/metadata/conceptvariable/vardok/1919/nb"],
+        ["https://metadata.ssb.no/variable-definitions/qSDlxNVO"]
+      ]
+    },
+    "owner": {
+      "description": "Eier av variabelen dvs. ansvarlig Dapla-team (statistikk-team) og informasjon om tilgangsstyringsgrupper. Team-tilhørighet settes automatisk til det samme som teamtilhørigheten til den som oppretter variabelen.",
+      "$ref": "#/$defs/Owner"
+    },
+    "contact": {
+      "description": "Her dokumenterer en navn og epost for person eller gruppe som kan svare på spørsmål.",
+      "$ref": "#/$defs/Contact"
+    },
+    "created_at": {
+      "type": "string",
+      "description": "Tidsstempelet da variabelen ble opprettet. Denne er maskingenerert.",
+      "format": "date-time"
+    },
+    "created_by": {
+      "type": "string",
+      "description": "Personen som har opprettet variabelen. Dette er maskingenerert."
+    },
+    "last_updated_at": {
+      "type": "string",
+      "description": "Tidsstempelet da variabelen sist ble oppdatert. Denne er maskingenerert.",
+      "format": "date-time"
+    },
+    "last_updated_by": {
+      "type": "string",
+      "description": "Personen som sist utførte en endring i variabelen. Denne er maskingenerert."
+    }
+  },
+  "$defs": {
+    "Contact": {
+      "required": ["email", "title"],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/LanguageStringType"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      }
+    },
+    "LanguageStringType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nb": {
+          "type": ["string", "null"],
+          "description": "Norwegian Bokmål",
+          "nullable": true
+        },
+        "nn": {
+          "type": ["string", "null"],
+          "description": "Norwegian Nynorsk",
+          "nullable": true
+        },
+        "en": {
+          "type": ["string", "null"],
+          "description": "English",
+          "nullable": true
+        }
+      },
+      "description": "Language string type Represents one text, with translations for the languages in \\[SupportedLanguages\\]. All fields are nullable to allow for flexibility for maintainers."
+    },
+    "Owner": {
+      "required": ["groups", "team"],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "team": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "groups": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      },
+      "description": "Owner",
+      "examples": [
+        {
+          "team": "play-obr-b",
+          "groups": ["play-obr-b-developers"]
+        }
+      ]
+    },
+    "VariableStatus": {
+      "type": "string",
+      "additionalProperties": false,
+      "description": "Life cycle status of a variable definition.",
+      "enum": ["DRAFT", "PUBLISHED_INTERNAL", "PUBLISHED_EXTERNAL"]
+    }
+  }
+}

--- a/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
+++ b/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
@@ -8,29 +8,33 @@ short_name: |
 definition: |
   En definisjon skal beskrive hva variabelen betyr og være så kort og presis som mulig. Mer utfyllende opplysninger kan legges i Merknad-feltet.
 classification_reference: |
-  Lenke (URI) til kodeverk (klassifikasjon eller kodeliste) i KLASS som beskriver verdiene variabelen kan anta. F.eks. vil variabelen “Sivilstand” ha kodeverks-URI Standard for [sivilstand](https://www.ssb.no/klass/klassifikasjoner/19).
+  ID av en klassifikasjon eller kodeliste fra KLASS som beskriver verdiene variabelen kan anta.
+  For eksempel vil variabelen 'Sivilstand' ha klassifikasjon 'Standard for sivilstand' (kan vises på https://www.ssb.no/klass/klassifikasjoner/19 ) som har ID 19.
 unit_types: |
-  Enhetstype(r) - enheten(e) som beskrives av denne variabelen. Variabelen “sivilstand” vil f.eks. ha enhetstypen person, mens f.eks. “Produsentpris for tjenester” vil ha både foretak og bedrift som enhetstyper siden variabelen kan beskrive begge.
-  ref: https://www.ssb.no/klass/klassifikasjoner/702.
+  Enhetstyper - enhetene som beskrives av denne variabelen. Variabelen “sivilstand” vil f.eks. ha enhetstypen person, mens f.eks. “Produsentpris for tjenester” vil ha både foretak og bedrift som enhetstyper siden variabelen kan beskrive begge.
+  Verdier skal være koder fra: https://www.ssb.no/klass/klassifikasjoner/702.
 subject_fields: |
-  Statistikkområde(r) som variabelen brukes innenfor, hentet fra [Kodeliste for statistikkområder i Statistikkbanken](https://www.ssb.no/klass/klassifikasjoner/618).
-  F.eks. tilhører variabelen “Sivilstand” statistikkområdet “Befolkning”.
+  Statistikkområder som variabelen brukes innenfor. For eksempel tilhører variabelen “Sivilstand” statistikkområdet “Befolkning”.
+  Verdier skal være koder fra https://www.ssb.no/klass/klassifikasjoner/618.
 contains_special_categories_of_personal_data: |
-  Viser om variabelen inneholder spesielt sensitive personopplysninger [Lov om behandling av personopplysninger(personopplysningsloven)-KAPITTEL || Prinsipper - Lovdata](https://lovdata.no/dokument/NL/lov/2018-06-15-38/KAPITTEL_gdpr-2#gdpr/a9)
-  - opplysninger om etnisk opprinnelse
-  - opplysninger om politisk oppfatning
-  - opplysninger om religion
-  - opplysninger om filosofisk overbevisning
-  - opplysninger om fagforeningsmedlemskap
-  - genetiske opplysninger
-  - biometriske opplysninger med det formål å entydig identifisere noen
-  - helseopplysninger
-  - opplysninger om seksuelle forhold
-  - opplysninger om seksuell legning
+  Viser om variabelen inneholder spesielt sensitive personopplysninger.
+  Kategorier:
+    - opplysninger om etnisk opprinnelse
+    - opplysninger om politisk oppfatning
+    - opplysninger om religion
+    - opplysninger om filosofisk overbevisning
+    - opplysninger om fagforeningsmedlemskap
+    - genetiske opplysninger
+    - biometriske opplysninger med det formål å entydig identifisere noen
+    - helseopplysninger
+    - opplysninger om seksuelle forhold
+    - opplysninger om seksuell legning
+  ref: https://lovdata.no/dokument/NL/lov/2018-06-15-38/KAPITTEL_gdpr-2#gdpr/a9
 measurement_type: |
-  Måletype som en kvantitativ variabelen tilhører, f.eks.  valuta, areal osv. Disse ligger i kodeverket [SSB måletyper/måleenheter](https://www.ssb.no/klass/klassifikasjoner/303/koder)
+  Måletype som en kvantitativ variabelen tilhører, f.eks.  valuta, areal osv.
+  Verdien skal være en kode fra: https://www.ssb.no/klass/klassifikasjoner/303
 valid_from: |
-  Datoen variabeldefinisjonen er gyldig  f.o.m.
+  Datoen variabeldefinisjonen er gyldig f.o.m.
 valid_until: |
   Datoen variabeldefinisjonens var gyldig t.o.m. Settes hvis definisjonen skal erstattet av en ny definisjon (med en ny gyldighetsperiode), eller variabelen ikke lenger skal brukes.
 external_reference_uri:  |
@@ -38,11 +42,11 @@ external_reference_uri:  |
 comment: |
   Her kan en sette inn eventuelle tilleggsopplysninger som ikke hører hjemme i selve definisjonen. Variabelen “Landbakgrunn” har f.eks. merknaden “Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland”.
 related_variable_definition_uris: |
-  Her kan en legge inn URI(er) til andre variabler som er relevante. Eksempelvis er variabelen “Inntekt etter skatt” en beregnet variabel der  “Yrkesinntekter” og “Kapitalinntekter” inngår i beregningen. En kan da legge inn deres URI-er i dette feltet.
+  Her kan en legge inn URIer til andre variabler som er relevante. Eksempelvis er variabelen “Inntekt etter skatt” en beregnet variabel der  “Yrkesinntekter” og “Kapitalinntekter” inngår i beregningen. En kan da legge inn deres URI-er i dette feltet.
 contact: |
   Her dokumenterer en navn og epost for person eller gruppe som kan svare på spørsmål.
 variable_status: |
-  Livssyklus for variabelen. Denne har tre kategorier: Utkast, Publisert internt og Publisert eksternt.
+  Livssyklus for variabelen.
 id: |
   Unik SSB identifikator for variabeldefinisjonen. Denne blir maskingenerert.
   Variabeldefinisjoner med ulike gyldighetsperioder har samme ID (og samme kortnavn).
@@ -50,14 +54,11 @@ patch_id: |
   Løpenummer som identifiserer en patch, endring, for en variabeldefinisjon.
 owner: |
   Eier av variabelen dvs. ansvarlig Dapla-team (statistikk-team) og informasjon om tilgangsstyringsgrupper. Team-tilhørighet settes automatisk til det samme som teamtilhørigheten til den som oppretter variabelen.
-  Eksempel:
-  team: ledstil
-  groups: [developers]
 created_at: |
-  Datoen variabelen ble opprettet. Denne er maskingenerert.
+  Tidsstempelet da variabelen ble opprettet. Denne er maskingenerert.
 created_by: |
-  Personen som har opprettet variabelen (initialer). Dette er maskingenerert.
+  Personen som har opprettet variabelen. Dette er maskingenerert.
 last_updated_at: |
-  Dato da variabelen sist ble oppdatert. Denne er maskingenerert.
+  Tidsstempelet da variabelen sist ble oppdatert. Denne er maskingenerert.
 last_updated_by: |
-  Personen (initialer) som sist utførte en endring i variabelen. Denne er maskingenerert.
+  Personen som sist utførte en endring i variabelen. Denne er maskingenerert.

--- a/tests/variable_definitions/resources/variable_definition_editing_files/variable_definition_arbkonfl_qSDlxNVO_2025-03-04T09-46-14.yaml
+++ b/tests/variable_definitions/resources/variable_definition_editing_files/variable_definition_arbkonfl_qSDlxNVO_2025-03-04T09-46-14.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../../../../schemas/jsonschema/complete-response-schema.json
+
 # --- Variable definition ---
 # Name of the variable. Must be unique for a given Unit Type and Owner combination.
 name:


### PR DESCRIPTION
- To assist with correctly editing variable definition files, we provide
a json-schema.
- This may be used in VS Code and other text editors to provide
information to the user about the meaning of fields and provide feedback
when a value is incorrect.
- A usage example of this may be explored in `tests/variable_definitions/resources/variable_definition_editing_files/variable_definition_arbkonfl_qSDlxNVO_2025-03-04T09-46-14.yaml`
- In future work, we will configure a service such that this is automatically connected to users' files.

![Screenshot 2025-04-01 at 16 12 22](https://github.com/user-attachments/assets/99ffa35f-46e2-4057-bf35-055bc41fa568)
