### PR TITLE
Add concrete data types to dataset parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-metadata"
-version = "0.6.0"
+version = "0.6.1"
 description = "Dapla Toolbelt Metadata"
 authors = ["Team Metadata <metadata@ssb.no>"]
 license = "MIT"

--- a/src/dapla_metadata/datasets/dataset_parser.py
+++ b/src/dapla_metadata/datasets/dataset_parser.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import pathlib  # noqa: TC003 import is needed for docs build
 import re
-import typing as t
 from abc import ABC
 from abc import abstractmethod
 from typing import TYPE_CHECKING
@@ -56,6 +55,8 @@ KNOWN_FLOAT_TYPES = (
 
 KNOWN_STRING_TYPES = (
     "string",
+    "string[pyarrow]",
+    "large_string",
     "str",
     "char",
     "varchar",
@@ -67,13 +68,18 @@ KNOWN_STRING_TYPES = (
 
 KNOWN_DATETIME_TYPES = (
     "timestamp",
+    "timestamp[s]",
+    "timestamp[ms]",
     "timestamp[us]",
     "timestamp[ns]",
-    "datetime64",
-    " datetime64[ns]",
-    " datetime64[us]",
-    "date",
     "datetime",
+    "datetime64",
+    "datetime64[s]",
+    "datetime64[ms]",
+    "datetime64[us]",
+    "datetime64[ns]",
+    "date",
+    "date32[day]",
     "time",
 )
 
@@ -90,8 +96,6 @@ TYPE_CORRESPONDENCE: list[tuple[tuple[str, ...], DataType]] = [
 TYPE_MAP: dict[str, DataType] = {}
 for concrete_type, abstract_type in TYPE_CORRESPONDENCE:
     TYPE_MAP.update(dict.fromkeys(concrete_type, abstract_type))
-
-TDatasetParser = t.TypeVar("TDatasetParser", bound="DatasetParser")
 
 
 class DatasetParser(ABC):
@@ -118,7 +122,7 @@ class DatasetParser(ABC):
             # Gzipped parquet files can be read with DatasetParserParquet
             match = re.search(PARQUET_GZIP_FILE_SUFFIX, str(dataset).lower())
             file_type = PARQUET_GZIP_FILE_SUFFIX if match else file_type
-            # Extract the appropriate reader class from the SUPPORTED_FILE_TYPES dict and return an instance of it
+            # Extract the appropriate reader class from the SUPPORTED_FILE_TYPES dict
             reader = SUPPORTED_DATASET_FILE_SUFFIXES[file_type](dataset)
         except IndexError as e:
             # Thrown when just one element is returned from split, meaning there is no file extension supplied
@@ -149,6 +153,9 @@ class DatasetParser(ABC):
 
         Arguments:
             data_type: The concrete data type to map.
+
+        Returns:
+            The abstract data type or None
         """
         return TYPE_MAP.get(data_type.lower(), None)
 

--- a/tests/datasets/test_dataset_parser.py
+++ b/tests/datasets/test_dataset_parser.py
@@ -36,18 +36,17 @@ def test_use_abstract_class_directly():
 )
 def test_get_fields_parquet(local_parser: DatasetParserParquet):
     expected_fields = [
-        Variable(short_name="pers_id", data_type=DataType.STRING),  # type: ignore  # noqa: PGH003
-        Variable(short_name="tidspunkt", data_type=DataType.DATETIME),  # type: ignore  # noqa: PGH003
-        Variable(short_name="sivilstand", data_type=DataType.STRING),  # type: ignore  # noqa: PGH003
-        Variable(short_name="alm_inntekt", data_type=DataType.INTEGER),  # type: ignore  # noqa: PGH003
-        Variable(short_name="sykepenger", data_type=DataType.INTEGER),  # type: ignore  # noqa: PGH003
-        Variable(short_name="ber_bruttoformue", data_type=DataType.INTEGER),  # type: ignore  # noqa: PGH003
-        Variable(short_name="fullf_utdanning", data_type=DataType.STRING),  # type: ignore  # noqa: PGH003
-        Variable(short_name="hoveddiagnose", data_type=DataType.STRING),  # type: ignore  # noqa: PGH003
+        Variable(short_name="pers_id", data_type=DataType.STRING),
+        Variable(short_name="tidspunkt", data_type=DataType.DATETIME),
+        Variable(short_name="sivilstand", data_type=DataType.STRING),
+        Variable(short_name="alm_inntekt", data_type=DataType.INTEGER),
+        Variable(short_name="sykepenger", data_type=DataType.INTEGER),
+        Variable(short_name="ber_bruttoformue", data_type=DataType.INTEGER),
+        Variable(short_name="fullf_utdanning", data_type=DataType.STRING),
+        Variable(short_name="hoveddiagnose", data_type=DataType.STRING),
     ]
-    fields = local_parser.get_fields()
 
-    assert fields == expected_fields
+    assert local_parser.get_fields() == expected_fields
 
 
 def test_get_fields_sas7bdat():


### PR DESCRIPTION
Adding:
- string[pyarrow]
- large_string
- timestamp[s]
- timestamp[ms]
- date32[day]
- datetime64[s]
- datetime64[ms]

Resolves #181 
