### PR TITLE
Standards notebook adhere to kvakk standards

### DIFF
--- a/demo/standards/navnestandard.ipynb
+++ b/demo/standards/navnestandard.ipynb
@@ -34,7 +34,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = await check_naming_standard(input(\"Filsti til bøtte, mappe eller fil:\"))"
+    "async def run_name_validator(file_path: str) -> list:\n",
+    "    validations = await check_naming_standard(file_path)\n",
+    "    return validations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = await run_name_validator(\"/buckets/produkt/stat/inndata/bil_p2021_v1.parquet\")"
    ]
   },
   {

--- a/demo/standards/navnestandard.ipynb
+++ b/demo/standards/navnestandard.ipynb
@@ -25,7 +25,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Kjøre navnestandard validering"
+    "## Kjøre navnestandard validering\n",
+    "Hvis koden skal lastes opp til et eget repo kan '# noqa: F704' være nødvendig for å unngå pre-commit-feil.\n"
    ]
   },
   {
@@ -34,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = await check_naming_standard(\"Skriv inn filsti til bøtte, mappe eller fil her\")  # noqa: F704"
+    "results = await check_naming_standard(input(\"Filsti til bøtte, mappe eller fil:\"))  # noqa: F704"
    ]
   },
   {

--- a/demo/standards/navnestandard.ipynb
+++ b/demo/standards/navnestandard.ipynb
@@ -34,27 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "async def run_name_validator(file_path: str) -> list:\n",
-    "    validations = await check_naming_standard(file_path)\n",
-    "    return validations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "results = await check_naming_standard(input(\"Filsti til bøtte, mappe eller fil:\"))  # noqa: F704"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "results = await run_name_validator(\"/buckets/produkt/stat/inndata/bil_p2021_v1.parquet\")"
+    "results = await check_naming_standard(\"Skriv inn filsti til bøtte, mappe eller fil her\")  # noqa: F704"
    ]
   },
   {

--- a/demo/standards/navnestandard.ipynb
+++ b/demo/standards/navnestandard.ipynb
@@ -45,6 +45,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "results = await check_naming_standard(input(\"Filsti til bøtte, mappe eller fil:\"))  # noqa: F704"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "results = await run_name_validator(\"/buckets/produkt/stat/inndata/bil_p2021_v1.parquet\")"
    ]
   },


### PR DESCRIPTION
User would like to be able to commit this notebook to their own repos, but flake-8 pre-commit does not allow await outside async function. In Notebooks await can be used directly in cells.


