### PR TITLE
Separate publish variable definitions notebook

### DIFF
--- a/demo/variable_definitions/publisere_variabel_definisjon_eksternt.ipynb
+++ b/demo/variable_definitions/publisere_variabel_definisjon_eksternt.ipynb
@@ -95,11 +95,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mitt_kortnavn = input(\"Skriv inn kortnavn\").strip()\n",
+    "mitt_kortnavn = input(\"Skriv inn kortnavn: \").strip()\n",
     "min_variabel = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn)\n",
-    "assert min_variabel.variable_status != models.VariableStatus.PUBLISHED_EXTERNAL, (\n",
-    "    \"Variabelen er allerede publisert eksternt!\"\n",
-    ")"
+    "\n",
+    "if min_variabel.variable_status == models.VariableStatus.PUBLISHED_EXTERNAL:\n",
+    "    print(\n",
+    "        f\"Variabeldefinisjon '{min_variabel.short_name}' er allerede publisert eksternt!\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(\n",
+    "        f\"Variabeldefinisjon valgt: {min_variabel.short_name} (ID: {min_variabel.id}). Klar for ekstern publisering.\"\n",
+    "    )"
    ]
   },
   {

--- a/demo/variable_definitions/publisere_variabel_definisjon_eksternt.ipynb
+++ b/demo/variable_definitions/publisere_variabel_definisjon_eksternt.ipynb
@@ -55,7 +55,7 @@
    "source": [
     "## Viktig informasjon om publisering\n",
     "\n",
-    "Merk at prosessen med å publisere er irreversibel. Når en variabeldefinisjon er publisert eksternt kan den ikke avpubliseres eller slettes eller endres tilbake til å kun være publisert internt.\n",
+    "Merk at prosessen med å publisere er irreversibel. Når en variabeldefinisjon er publisert eksternt kan den ikke slettes, avpubliseres eller endres tilbake til å kun være publisert internt.\n",
     "\n",
     "Ved ekstern publisering må alle obligatoriske felt ha verdi.\n",
     "\n",

--- a/demo/variable_definitions/publisere_variabel_definisjon_eksternt.ipynb
+++ b/demo/variable_definitions/publisere_variabel_definisjon_eksternt.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Publisere en variabel definisjon eksternt\n",
+    "\n",
+    "Denne Notebook er for deg som:\n",
+    "\n",
+    "- Har en kvalitetsjekket variabeldefinisjon med status `UTKAST` eller `PUBLISERT_INTERNT`\n",
+    "- Ønsker å publisere eksternt\n",
+    "\n",
+    "Forutsetninger:\n",
+    "- Du må ha `Kortnavn` for variabeldefinisjonen du vil publisere\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Oppsett\n",
+    "\n",
+    "Koden under kjøres som forberedelse for påfølgende steg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Nødvendig import\n",
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "from dapla_metadata.variable_definitions import Vardef\n",
+    "from dapla_metadata.variable_definitions import models\n",
+    "\n",
+    "# Redusere størrelsen på Traceback for mer tydelige feilmeldinger\n",
+    "%xmode Minimal\n",
+    "\n",
+    "# Gjøre at logging vises\n",
+    "logging.basicConfig(\n",
+    "    format=\"%(levelname)s: %(message)s\",\n",
+    "    level=logging.INFO,\n",
+    "    stream=sys.stdout,\n",
+    "    force=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Viktig informasjon om publisering\n",
+    "\n",
+    "Merk at prosessen med å publisere er irreversibel. Når en variabeldefinisjon er publisert eksternt kan den ikke avpubliseres eller slettes eller endres tilbake til å kun være publisert internt.\n",
+    "\n",
+    "Ved ekstern publisering må alle obligatoriske felt ha verdi.\n",
+    "\n",
+    "Obligatoriske felt:\n",
+    "- navn (`name`)\n",
+    "- kortnavn (`short_name`)\n",
+    "- definisjon (`definition`)\n",
+    "- enhetstyper (`unit_types`)\n",
+    "- statistikkområder (`subject_fields`)\n",
+    "- inneholder særlige kategorier av personopplysninger(`contains_special_categories_of_personal_data`)\n",
+    "- gyldig f.o.m.(`valid_from`)\n",
+    "- kontakt(`contact`)\n",
+    "- eier (`owner`)\n",
+    "\n",
+    "Flerspråklige felt (som for eksempel `navn` eller `definisjon`) må ha verdier på alle språk (bokmål, nynorsk og engelsk). \n",
+    "Lister (som for eksempel `enhetstyper`) må ha minst et element i listen.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hente ut variabeldefinisjon\n",
+    "\n",
+    "Kjør cellen under. \n",
+    "\n",
+    "Et input-felt vises – skriv inn kortnavnet ditt og trykk **Enter**.\n",
+    "\n",
+    "⚠ Viktig: Trykk alltid **Enter**, selv om du ikke skriver noe, for å unngå at Jupyter-kjernen henger seg opp.\n",
+    "\n",
+    "Her henter vi variabeldefinisjonen som skal publisereres."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mitt_kortnavn = input(\"Skriv inn kortnavn\").strip()\n",
+    "min_variabel = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn)\n",
+    "assert min_variabel.variable_status != models.VariableStatus.PUBLISHED_EXTERNAL, (\n",
+    "    \"Variabelen er allerede publisert eksternt!\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Publisere eksternt\n",
+    "\n",
+    "I koden under lagres oppdatert status i Vardef. \n",
+    "\n",
+    "For at statusendringen skal tre i kraft må dette steget fullføres uten feil.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_variabel = min_variabel.publish_external()\n",
+    "print(f\"Ny status: {min_variabel.variable_status}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython"
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/demo/variable_definitions/publisere_variabel_definisjon_internt.ipynb
+++ b/demo/variable_definitions/publisere_variabel_definisjon_internt.ipynb
@@ -4,12 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Publisere en variabel definisjon\n",
+    "# Publisere en variabel definisjon internt\n",
     "\n",
     "Denne Notebook er for deg som:\n",
     "\n",
-    "- Har en kvalitetsjekket variabeldefinisjon med status `UTKAST` eller `PUBLISERT_INTERNT`\n",
-    "- Ønsker å publisere internt eller eksternt\n",
+    "- Har en kvalitetsjekket variabeldefinisjon med status `UTKAST`\n",
+    "- Ønsker å publisere internt\n",
     "\n",
     "Forutsetninger:\n",
     "- Du må ha `Kortnavn` for variabeldefinisjonen du vil publisere\n"
@@ -53,17 +53,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Viktig informasjon om publisering\n",
+    "## Viktig informasjon om publisering internt\n",
     "\n",
-    "Merk at prosessen med å publisere er irreversibel. Når en variabeldefinisjon er publisert kan den ikke avpubliseres eller slettes.\n",
-    "\n",
-    "Det er ulike regler som gjelder ved publisering internt og eksternt.\n",
+    "Merk at prosessen med å publisere er irreversibel. Når en variabeldefinisjon er publisert kan den ikke avpubliseres eller slettes. \n",
     "\n",
     "Ved intern publisering må alle obligatoriske felt ha verdi.\n",
     "\n",
-    "Ved ekstern publisere må i tillegg alle felt som er flerspråklige ha verdier på alle språk (bokmål, nynorsk og engelsk).\n",
+    "Obligatoriske felt:\n",
+    "- navn (`name`)\n",
+    "- kortnavn (`short_name`)\n",
+    "- definisjon (`definition`)\n",
+    "- enhetstyper (`unit_types`)\n",
+    "- statistikkområder (`subject_fields`)\n",
+    "- inneholder særlige kategorier av personopplysninger(`contains_special_categories_of_personal_data`)\n",
+    "- gyldig f.o.m.(`valid_from`)\n",
+    "- kontakt(`contact`)\n",
+    "- eier (`owner`)\n",
     "\n",
-    "Merk også at når en variabeldefinisjon er publisert eksternt kan den ikke endres tilbake til å kun være publisert internt."
+    "Flerspråklige felt (som for eksempel `navn` eller `definisjon`) må ha verdi på minst et språk (bokmål, nynorsk eller engelsk). \n",
+    "Lister (som for eksempel `enhetstyper`) må ha minst et element i listen."
    ]
   },
   {
@@ -89,8 +97,8 @@
    "source": [
     "mitt_kortnavn = input(\"Skriv inn kortnavn\").strip()\n",
     "min_variabel = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn)\n",
-    "assert min_variabel.variable_status != models.VariableStatus.PUBLISHED_EXTERNAL, (\n",
-    "    \"Variabelen er allerede publisert!\"\n",
+    "assert min_variabel.variable_status != models.VariableStatus.PUBLISHED_INTERNAL, (\n",
+    "    \"Variabelen er allerede publisert internt!\"\n",
     ")"
    ]
   },
@@ -98,21 +106,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Publisere\n",
-    "\n",
-    "⚠ **Velg kun én av publiseringsmetodene nedenfor – ikke begge.**\n",
+    "## Publisere internt\n",
     "\n",
     "I koden under lagres oppdatert status i Vardef. \n",
     "\n",
     "For at statusendringen skal tre i kraft må dette steget fullføres uten feil.\n",
     "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Publisere internt"
    ]
   },
   {
@@ -122,25 +121,6 @@
    "outputs": [],
    "source": [
     "min_variabel = min_variabel.publish_internal()\n",
-    "print(f\"Ny status: {min_variabel.variable_status}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Publisere eksternt\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "min_variabel = min_variabel.publish_external()\n",
     "print(f\"Ny status: {min_variabel.variable_status}\")"
    ]
   }

--- a/demo/variable_definitions/publisere_variabel_definisjon_internt.ipynb
+++ b/demo/variable_definitions/publisere_variabel_definisjon_internt.ipynb
@@ -97,9 +97,16 @@
    "source": [
     "mitt_kortnavn = input(\"Skriv inn kortnavn\").strip()\n",
     "min_variabel = Vardef.get_variable_definition_by_shortname(short_name=mitt_kortnavn)\n",
-    "assert min_variabel.variable_status != models.VariableStatus.PUBLISHED_INTERNAL, (\n",
-    "    \"Variabelen er allerede publisert internt!\"\n",
-    ")"
+    "\n",
+    "if min_variabel.variable_status in {\n",
+    "    models.VariableStatus.PUBLISHED_EXTERNAL,\n",
+    "    models.VariableStatus.PUBLISHED_INTERNAL,\n",
+    "}:\n",
+    "    print(f\"Variabeldefinisjon '{min_variabel.short_name}' er allerede publisert!\")\n",
+    "else:\n",
+    "    print(\n",
+    "        f\"Variabeldefinisjon valgt: {min_variabel.short_name} (ID: {min_variabel.id}). Klar for intern publisering.\"\n",
+    "    )"
    ]
   },
   {

--- a/demo/variable_definitions/publisere_variabel_definisjon_internt.ipynb
+++ b/demo/variable_definitions/publisere_variabel_definisjon_internt.ipynb
@@ -55,7 +55,7 @@
    "source": [
     "## Viktig informasjon om publisering internt\n",
     "\n",
-    "Merk at prosessen med å publisere er irreversibel. Når en variabeldefinisjon er publisert kan den ikke avpubliseres eller slettes. \n",
+    "Merk at prosessen med å publisere er irreversibel. Når en variabeldefinisjon er publisert kan den ikke slettes eller avpubliseres.\n",
     "\n",
     "Ved intern publisering må alle obligatoriske felt ha verdi.\n",
     "\n",


### PR DESCRIPTION
- One notebook for publish internal for variable definitions with status `DRAFT`
- One notebook for publish external for variable definitions with either status `DRAFT` or `PUBLISHED_INTERNAL`
- Add user feedback to confirm the selected variable definition before proceeding with publication as requested by users

Reviewer should confirm that all rules regarding publishing are correct and the text is not ambiguous

