### PR TITLE
Update .gitignore to match kvakk standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 *.xlsx
 *.zip
 *.rda
+*.rej
 
 # Blaise
 *.bdix
@@ -42,6 +43,7 @@
 # Notebooks shall be stored in .py or .R-format.
 # See https://adr.ssb.no/0020-lagringsformat-for-jupyter-notebooks/
 *.ipynb
+
 # Unignore all ipynb files under `demo/`
 !demo/**/*.ipynb
 
@@ -148,6 +150,12 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
@@ -160,8 +168,10 @@ ipython_config.py
 #pdm.lock
 #   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
 #   in version control.
-#   https://pdm.fming.dev/#use-with-ide
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
 .pdm.toml
+.pdm-python
+.pdm-build/
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -213,6 +223,12 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
 
 
 # The section below is from the GitHub .gitignore template for R:

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 
 *.db
 *.feather
+*.gz
+*.orig
 
 *.parquet
 # Unignore all parquet files under `tests/datasets/resources/`
@@ -25,6 +27,17 @@
 *.xls
 *.xlsx
 *.zip
+*.rda
+
+# Blaise
+*.bdix
+*.bdbx
+*.bpkg
+*.mbpkg
+*.backup
+*.bmix
+*.msux
+*.usersettings
 
 # Notebooks shall be stored in .py or .R-format.
 # See https://adr.ssb.no/0020-lagringsformat-for-jupyter-notebooks/
@@ -40,7 +53,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-.poetry/cache/
+**/.poetry/cache/
 
 # C extensions
 *.so
@@ -89,6 +102,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+cover/
 
 # Translations
 *.mo
@@ -111,6 +125,7 @@ instance/
 docs/_build/
 
 # PyBuilder
+.pybuilder/
 target/
 
 # Jupyter Notebook
@@ -121,6 +136,9 @@ profile_default/
 ipython_config.py
 
 # pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
 .python-version
 
 # pipenv
@@ -130,7 +148,22 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 
 # Celery stuff
@@ -167,10 +200,75 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
 # PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
 .idea/
 
-/.python-version
+
+# The section below is from the GitHub .gitignore template for R:
+# https://raw.githubusercontent.com/github/gitignore/main/R.gitignore
+
+# History files
+.Rhistory
+.Rapp.history
+
+# Session Data files
+.RData
+.RDataTmp
+
+# User-specific files
+.Ruserdata
+
+# Example code in package build process
+*-Ex.R
+
+# Output files from R CMD build
+/*.tar.gz
+
+# Output files from R CMD check
+/*.Rcheck/
+
+# RStudio files
+.Rproj.user/
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
+.httr-oauth
+
+# knitr and R markdown default cache directories
+*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md
+
+# R Environment Variables
+.Renviron
+
+# pkgdown site
+# SSB: The directory below is commented out because default when generating documentation with Sphinx
+#docs/
+
+# translation temp files
+po/*~
+
+# RStudio Connect folder
+rsconnect/
+
 /.pytype/
 /docs/_build/
 


### PR DESCRIPTION
Based on the reference gitignore file here: https://github.com/statisticsnorway/kvakk-git-tools/blob/main/kvakk_git_tools/recommended/gitignore we add all the missing lines.

This will still fail when used with `ssb-project build` because ssb-project does not fetch the reference gitignore file, but holds its own outdated copy. There is currently work underway to fix this and after that is complete this repo should pass the validation.