### PR TITLE
Fix deprecated accessing attribute on instance

### DIFF
--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -120,7 +120,7 @@ def _populate_commented_map(
 ) -> None:
     """Add data to a CommentedMap."""
     commented_map[field_name] = value
-    field = model_instance.model_fields[field_name]
+    field = type(model_instance).model_fields[field_name]
     description: JsonValue = cast(
         JsonDict,
         field.json_schema_extra,


### PR DESCRIPTION
Accessing model_fields from instance is deprecated in Pydantic v3.
Instead use instance to access the class.