### PR TITLE
Fix misleading name validation result

### DIFF
--- a/src/dapla_metadata/standards/name_validator.py
+++ b/src/dapla_metadata/standards/name_validator.py
@@ -128,9 +128,9 @@ class NamingStandardReport:
         """Returns an appropriate message based on the success rate."""
         rate = self.success_rate()
         if rate is not None:
-            if rate == 100:
+            if 95 <= rate <= 100:
                 return SSB_NAMING_STANDARD_REPORT_RESULT_BEST
-            if 70 < rate < 100:
+            if 70 < rate < 95:
                 return SSB_NAMING_STANDARD_REPORT_RESULT_GOOD
             if 40 <= rate <= 70:
                 return SSB_NAMING_STANDARD_REPORT_RESULT_AVERAGE

--- a/src/dapla_metadata/standards/utils/constants.py
+++ b/src/dapla_metadata/standards/utils/constants.py
@@ -9,7 +9,7 @@ NAME_STANDARD_SUCCESS = "Filene dine er i samsvar med SSB-navnestandarden"
 NAME_STANDARD_VIOLATION = "Det er oppdaget brudd på SSB-navnestandard:"
 
 MISSING_BUCKET_NAME = "Filnavn mangler bøttenavn ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#obligatoriske-mapper"
-MISSING_VERSION = "Filnavn mangler versjon ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#filnavn"
+MISSING_VERSION = "Filnavn mangler versjon, hvis ikke filen er nyeste versjon kan dette være brudd på navnestandarden ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#versjonering-av-datasett"
 MISSING_PERIOD = "Filnavn mangler gyldighetsperiode ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#filnavn"
 MISSING_SHORT_NAME = "Kortnavn for statistikk mangler ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#obligatoriske-mapper"
 MISSING_DATA_STATE = "Mappe for datatilstand mangler ref: https://manual.dapla.ssb.no/statistikkere/navnestandard.html#obligatoriske-mapper"

--- a/src/dapla_metadata/standards/utils/constants.py
+++ b/src/dapla_metadata/standards/utils/constants.py
@@ -26,7 +26,7 @@ BUCKET_NAME_UNKNOWN = "Kan ikke validere bøttenavn"
 
 SSB_NAMING_STANDARD_REPORT = "SSB navnestandard rapport"
 SSB_NAMING_STANDARD_REPORT_SUCCESS_RATE = "Suksess rate"
-SSB_NAMING_STANDARD_REPORT_RESULT_BEST = "🚀 Fantastisk! Alt bestått! 🎉\n"
+SSB_NAMING_STANDARD_REPORT_RESULT_BEST = "🚀 Fantastisk! 🎉\n"
 SSB_NAMING_STANDARD_REPORT_RESULT_GOOD = (
     "✅ Bra jobba! Fortsatt litt rom for forbedring. 😊\n"
 )


### PR DESCRIPTION
Fix reported issue by users
- Update violation message to reflect the naming standard rule which allow omitting version on newest file
- Change from linking to filename chapter to versioning chapter
- Adjust percentage result in attempt to reflect the possibility for "success" also with score under 100%
