### PR TITLE
Improve template file

### DIFF
--- a/src/dapla_metadata/variable_definitions/_utils/constants.py
+++ b/src/dapla_metadata/variable_definitions/_utils/constants.py
@@ -41,3 +41,27 @@ OPTIONAL_FIELD = "~ Valgfritt felt ~"
 REQUIRED_FIELD = "! Obligatorisk felt !"
 
 YAML_STR_TAG = "tag:yaml.org,2002:str"
+
+FOLDED_FIELDS = [
+    ("definition", ["nb", "nn", "en"]),
+    ("name", ["nb", "nn", "en"]),
+    ("contact.title", ["nb", "nn", "en"]),
+]
+
+BLOCK_FIELDS = [("comment", ["nb", "nn", "en"])]
+
+LIST_FIELDS = [
+    "unit_types",
+    "subject_fields",
+    "related_variable_definition_uris",
+]
+
+SINGLE_LINE_FIELDS = [
+    "short_name",
+    "classification_reference",
+    "measurement_type",
+    "external_reference_uri",
+    "created_by",
+    "id",
+    "last_updated_by",
+]

--- a/src/dapla_metadata/variable_definitions/_utils/constants.py
+++ b/src/dapla_metadata/variable_definitions/_utils/constants.py
@@ -49,14 +49,11 @@ BLOCK_FIELDS = [
     ("comment", ["nb", "nn", "en"]),
 ]
 
-LIST_FIELDS = [
+DOUBLE_QUOTE_FIELDS = [
     "unit_types",
     "subject_fields",
     "related_variable_definition_uris",
     "owner",
-]
-
-SINGLE_LINE_FIELDS = [
     "short_name",
     "classification_reference",
     "measurement_type",

--- a/src/dapla_metadata/variable_definitions/_utils/constants.py
+++ b/src/dapla_metadata/variable_definitions/_utils/constants.py
@@ -53,6 +53,7 @@ LIST_FIELDS = [
     "unit_types",
     "subject_fields",
     "related_variable_definition_uris",
+    "owner",
 ]
 
 SINGLE_LINE_FIELDS = [

--- a/src/dapla_metadata/variable_definitions/_utils/constants.py
+++ b/src/dapla_metadata/variable_definitions/_utils/constants.py
@@ -42,13 +42,12 @@ REQUIRED_FIELD = "! Obligatorisk felt !"
 
 YAML_STR_TAG = "tag:yaml.org,2002:str"
 
-FOLDED_FIELDS = [
+BLOCK_FIELDS = [
     ("definition", ["nb", "nn", "en"]),
     ("name", ["nb", "nn", "en"]),
     ("contact.title", ["nb", "nn", "en"]),
+    ("comment", ["nb", "nn", "en"]),
 ]
-
-BLOCK_FIELDS = [("comment", ["nb", "nn", "en"])]
 
 LIST_FIELDS = [
     "unit_types",

--- a/src/dapla_metadata/variable_definitions/_utils/constants.py
+++ b/src/dapla_metadata/variable_definitions/_utils/constants.py
@@ -43,10 +43,10 @@ REQUIRED_FIELD = "! Obligatorisk felt !"
 YAML_STR_TAG = "tag:yaml.org,2002:str"
 
 BLOCK_FIELDS = [
-    ("definition", ["nb", "nn", "en"]),
-    ("name", ["nb", "nn", "en"]),
-    ("contact.title", ["nb", "nn", "en"]),
-    ("comment", ["nb", "nn", "en"]),
+    "definition",
+    "name",
+    "contact.title",
+    "comment",
 ]
 
 DOUBLE_QUOTE_FIELDS = [

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -189,7 +189,9 @@ def configure_yaml(yaml: YAML) -> YAML:
     yaml.preserve_quotes = True
     yaml.width = 180  # wrap long lines
     yaml.indent(
-        mapping=4, sequence=2, offset=0
+        mapping=4,
+        sequence=6,
+        offset=4,
     )  # Ensure indentation for nested keys and lists
     yaml.representer.add_representer(
         VariableStatus,

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -220,7 +220,7 @@ def _safe_set_multi_line_type(
     """Set the string type (Literal) for the specified field in the data dictionary."""
     keys = path.split(".")
     parent = _safe_get(data, keys)
-    if parent is not None:
+    if parent is not None and lang in parent and parent[lang] is not None:
         parent[lang] = LiteralScalarString(parent[lang])
 
 

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -213,15 +213,23 @@ def _safe_get(data: dict, keys: list):
     return data
 
 
-def _apply_literal_scalars_to_multi_language_fields(field: dict):
-    """Helper function to set `LiteralScalarString` type."""
+def _apply_literal_scalars(field: dict):
+    """Helper function to wrap `LanguageStringType` values in `LiteralScalarString`.
+
+    This function wraps each non-`None` language value in a `LanguageStringType` field
+    in the `LiteralScalarString` YAML type, ensuring proper YAML formatting with block style.
+    """
     for lang, value in field.items():
         if value is not None:
             field[lang] = LiteralScalarString(value)
 
 
 def _apply_double_quotes_to_dict_values(field: dict):
-    """Helper function to set `DoubleQuotedScalarString` type."""
+    """Helper function to wrap dictionary values in `DoubleQuotedScalarString`.
+
+    This function wraps each non-`None` value in a dictionary, including values inside lists,
+    in the `DoubleQuotedScalarString` YAML type, ensuring proper YAML formatting with double quotes.
+    """
     for sub_key, sub_value in field.items():
         if isinstance(sub_value, list):
             field[sub_key] = [
@@ -232,12 +240,12 @@ def _apply_double_quotes_to_dict_values(field: dict):
 
 
 def pre_process_data(data: dict) -> dict:
-    """Format Variable definition model fields with ruamel yaml scalar string types.
+    """Format variable definition model fields with ruamel YAML scalar string types.
 
     This method sets the appropriate scalar string type (either `LiteralScalarString` or `DoubleQuotedScalarString`)
-    for the fields of the variable definition model, based on predefined lists of fields.
+    for fields of the variable definition model, based on predefined lists of fields.
 
-    It processes both nested dictionaries and lists, applying the correct formatting to each element.
+    It processes both nested dictionaries and lists, ensuring each element is formatted with the correct YAML string type.
 
     Args:
         data (dict): A dictionary containing the variable definition data.
@@ -249,7 +257,7 @@ def pre_process_data(data: dict) -> dict:
         keys = key.split(".")
         field = _safe_get(data, keys)
         if isinstance(field, dict):
-            _apply_literal_scalars_to_multi_language_fields(field)
+            _apply_literal_scalars(field)
 
     for key in DOUBLE_QUOTE_FIELDS:
         keys = key.split(".")

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -212,14 +212,14 @@ def _safe_get(data: dict, keys: list):
 
 
 def _apply_literal_scalars_to_multi_language_fields(field: dict):
-    """Helper function to modify LanguageStringType fields."""
+    """Helper function to set LiteralScalarString type."""
     for lang, value in field.items():
         if value is not None:
             field[lang] = LiteralScalarString(value)
 
 
 def _apply_double_quotes_to_dict_values(field: dict):
-    """Helper function to modify dict fields which are not LanguageStringType."""
+    """Helper function to set DoubleQuotedScalarString type."""
     for sub_key, sub_value in field.items():
         if isinstance(sub_value, list):
             field[sub_key] = [

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -219,7 +219,7 @@ def _apply_literal_scalars_to_multi_language_fields(field: Any):
             field[lang] = LiteralScalarString(value)
 
 
-def _apply_double_quotes_to_dict_values(field: Any):
+def _apply_double_quotes_to_dict_values(field: dict):
     """Helper function to modify dict fields which are not LanguageStringType."""
     for sub_key, sub_value in field.items():
         if isinstance(sub_value, list):

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -311,8 +311,6 @@ def _model_to_yaml_with_comments(
                 model_instance,
             )
         elif field_name not in {VARIABLE_STATUS_FIELD_NAME, OWNER_FIELD_NAME}:
-            if isinstance(value, str):
-                value.strip()
             _populate_commented_map(field_name, value, commented_map, model_instance)
 
     base_path = (

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -4,7 +4,6 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Any
 from typing import cast
 
 import pytz
@@ -212,7 +211,7 @@ def _safe_get(data: dict, keys: list):
     return data
 
 
-def _apply_literal_scalars_to_multi_language_fields(field: Any):
+def _apply_literal_scalars_to_multi_language_fields(field: dict):
     """Helper function to modify LanguageStringType fields."""
     for lang, value in field.items():
         if value is not None:

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -13,6 +13,7 @@ from ruamel.yaml import CommentedMap
 from ruamel.yaml import RoundTripRepresenter
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 from ruamel.yaml.scalarstring import FoldedScalarString
+from ruamel.yaml.scalarstring import LiteralScalarString
 
 from dapla_metadata.variable_definitions._generated.vardef_client.models.complete_response import (
     CompleteResponse,
@@ -216,6 +217,13 @@ def _safe_set_folded(data: dict, path: str, lang: str):
         parent[lang] = FoldedScalarString(parent[lang])
 
 
+def _safe_set_block(data: dict, path: str, lang: str):
+    keys = path.split(".")
+    parent = _safe_get(data, keys)
+    if isinstance(parent, dict) and lang in parent and parent[lang] is not None:
+        parent[lang] = LiteralScalarString(parent[lang])
+
+
 def pre_process_data(data: dict) -> dict:
     """Format Variable definition model fields with ruamel yaml scalar string types."""
     folded_fields = [
@@ -226,7 +234,7 @@ def pre_process_data(data: dict) -> dict:
     ]
     for field_path, langs in folded_fields:
         for lang in langs:
-            _safe_set_folded(data, field_path, lang)
+            _safe_set_block(data, field_path, lang)
 
     list_fields = [
         "unit_types",

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -229,10 +229,14 @@ def pre_process_data(data: dict) -> dict:
     folded_fields = [
         ("definition", ["nb", "nn", "en"]),
         ("name", ["nb", "nn", "en"]),
-        ("comment", ["nb", "nn", "en"]),
         ("contact.title", ["nb", "nn", "en"]),
     ]
     for field_path, langs in folded_fields:
+        for lang in langs:
+            _safe_set_folded(data, field_path, lang)
+
+    block_fields = [("comment", ["nb", "nn", "en"])]
+    for field_path, langs in block_fields:
         for lang in langs:
             _safe_set_block(data, field_path, lang)
 

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -12,7 +12,6 @@ from ruamel.yaml import YAML
 from ruamel.yaml import CommentedMap
 from ruamel.yaml import RoundTripRepresenter
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
-from ruamel.yaml.scalarstring import FoldedScalarString
 from ruamel.yaml.scalarstring import LiteralScalarString
 
 from dapla_metadata.variable_definitions._generated.vardef_client.models.complete_response import (
@@ -23,7 +22,6 @@ from dapla_metadata.variable_definitions._generated.vardef_client.models.variabl
 )
 from dapla_metadata.variable_definitions._utils import config
 from dapla_metadata.variable_definitions._utils.constants import BLOCK_FIELDS
-from dapla_metadata.variable_definitions._utils.constants import FOLDED_FIELDS
 from dapla_metadata.variable_definitions._utils.constants import LIST_FIELDS
 from dapla_metadata.variable_definitions._utils.constants import (
     MACHINE_GENERATED_FIELDS,
@@ -215,33 +213,27 @@ def _safe_get(data: dict, keys: list):
 
 
 def _safe_set_multi_line_type(
-    data: dict, path: str, lang: str, string_type: str
+    data: dict,
+    path: str,
+    lang: str,
 ) -> None:
-    """Set the string type (Folded or Literal) for the specified field in the data dictionary."""
+    """Set the string type (Literal) for the specified field in the data dictionary."""
     keys = path.split(".")
     parent = _safe_get(data, keys)
-
-    if isinstance(parent, dict) and lang in parent and parent[lang] is not None:
-        if string_type == "folded":
-            parent[lang] = FoldedScalarString(parent[lang])
-        elif string_type == "block":
-            parent[lang] = LiteralScalarString(parent[lang])
+    if parent is not None:
+        parent[lang] = LiteralScalarString(parent[lang])
 
 
-def _apply_language_string_type_to_fields(
-    language_string_types: list, data: dict, string_type: str
-):
+def _apply_language_string_type_to_fields(language_string_types: list, data: dict):
     """Apply the specified language string type to multiple fields in the data dictionary."""
     for field_path, langs in language_string_types:
         for lang in langs:
-            _safe_set_multi_line_type(data, field_path, lang, string_type)
+            _safe_set_multi_line_type(data, field_path, lang)
 
 
 def pre_process_data(data: dict) -> dict:
     """Format Variable definition model fields with ruamel yaml scalar string types."""
-    _apply_language_string_type_to_fields(FOLDED_FIELDS, data, "folded")
-
-    _apply_language_string_type_to_fields(BLOCK_FIELDS, data, "block")
+    _apply_language_string_type_to_fields(BLOCK_FIELDS, data)
 
     for key in LIST_FIELDS:
         if isinstance(data.get(key), list):

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -212,14 +212,14 @@ def _safe_get(data: dict, keys: list):
 
 
 def _apply_literal_scalars_to_multi_language_fields(field: dict):
-    """Helper function to set LiteralScalarString type."""
+    """Helper function to set `LiteralScalarString` type."""
     for lang, value in field.items():
         if value is not None:
             field[lang] = LiteralScalarString(value)
 
 
 def _apply_double_quotes_to_dict_values(field: dict):
-    """Helper function to set DoubleQuotedScalarString type."""
+    """Helper function to set `DoubleQuotedScalarString` type."""
     for sub_key, sub_value in field.items():
         if isinstance(sub_value, list):
             field[sub_key] = [

--- a/src/dapla_metadata/variable_definitions/_utils/template_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/template_files.py
@@ -42,14 +42,14 @@ def _get_default_template() -> "VariableDefinition":
     return VariableDefinition(
         name=LanguageStringType(
             nb="Navn",
-            nn="",
-            en="",
+            nn=None,
+            en=None,
         ),
         short_name="generert_kortnavn",
         definition=LanguageStringType(
             nb="Definisjonstekst",
-            nn="",
-            en="",
+            nn=None,
+            en=None,
         ),
         valid_from=DEFAULT_DATE,
         unit_types=[""],
@@ -60,8 +60,8 @@ def _get_default_template() -> "VariableDefinition":
         contact=Contact(
             title=LanguageStringType(
                 nb="generert tittel",
-                nn="",
-                en="",
+                nn=None,
+                en=None,
             ),
             email="generert@ssb.no",
         ),

--- a/src/dapla_metadata/variable_definitions/_utils/template_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/template_files.py
@@ -55,7 +55,6 @@ def _get_default_template() -> "VariableDefinition":
         unit_types=[""],
         subject_fields=[""],
         contains_special_categories_of_personal_data=False,
-        variable_status=VariableStatus.DRAFT.value,
         owner=Owner(team="default team", groups=["default group"]),
         contact=Contact(
             title=LanguageStringType(
@@ -65,6 +64,8 @@ def _get_default_template() -> "VariableDefinition":
             ),
             email="generert@ssb.no",
         ),
+        comment=LanguageStringType(nb="Valgfri merknad"),
+        variable_status=VariableStatus.DRAFT.value,
         id="",
         patch_id=0,
         created_at=DEFAULT_DATE,

--- a/src/dapla_metadata/variable_definitions/_utils/template_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/template_files.py
@@ -64,6 +64,9 @@ def _get_default_template() -> "VariableDefinition":
             ),
             email="generert@ssb.no",
         ),
+        comment=LanguageStringType(
+            nb="Valgfri merknad",
+        ),
         variable_status=VariableStatus.DRAFT.value,
         id="",
         patch_id=0,

--- a/src/dapla_metadata/variable_definitions/_utils/template_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/template_files.py
@@ -64,9 +64,6 @@ def _get_default_template() -> "VariableDefinition":
             ),
             email="generert@ssb.no",
         ),
-        comment=LanguageStringType(
-            nb="Valgfri merknad",
-        ),
         variable_status=VariableStatus.DRAFT.value,
         id="",
         patch_id=0,

--- a/src/dapla_metadata/variable_definitions/_utils/template_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/template_files.py
@@ -41,15 +41,15 @@ def _get_default_template() -> "VariableDefinition":
 
     return VariableDefinition(
         name=LanguageStringType(
-            nb="navn",
-            nn="namn",
-            en="name",
+            nb="Navn",
+            nn="",
+            en="",
         ),
         short_name="generert_kortnavn",
         definition=LanguageStringType(
-            nb="definisjonstekst",
-            nn="definisjonstekst",
-            en="definition text",
+            nb="Definisjonstekst",
+            nn="",
+            en="",
         ),
         valid_from=DEFAULT_DATE,
         unit_types=[""],
@@ -60,15 +60,10 @@ def _get_default_template() -> "VariableDefinition":
         contact=Contact(
             title=LanguageStringType(
                 nb="generert tittel",
-                nn="generert tittel",
-                en="generert title",
+                nn="",
+                en="",
             ),
             email="generert@ssb.no",
-        ),
-        comment=LanguageStringType(
-            nb="",
-            nn="",
-            en="",
         ),
         id="",
         patch_id=0,

--- a/src/dapla_metadata/variable_definitions/_utils/template_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/template_files.py
@@ -42,14 +42,10 @@ def _get_default_template() -> "VariableDefinition":
     return VariableDefinition(
         name=LanguageStringType(
             nb="Navn",
-            nn=None,
-            en=None,
         ),
         short_name="generert_kortnavn",
         definition=LanguageStringType(
             nb="Definisjonstekst",
-            nn=None,
-            en=None,
         ),
         valid_from=DEFAULT_DATE,
         unit_types=[""],
@@ -59,8 +55,6 @@ def _get_default_template() -> "VariableDefinition":
         contact=Contact(
             title=LanguageStringType(
                 nb="generert tittel",
-                nn=None,
-                en=None,
             ),
             email="generert@ssb.no",
         ),

--- a/src/dapla_metadata/variable_definitions/_utils/template_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/template_files.py
@@ -64,7 +64,6 @@ def _get_default_template() -> "VariableDefinition":
             ),
             email="generert@ssb.no",
         ),
-        comment=LanguageStringType(nb="Valgfri merknad"),
         variable_status=VariableStatus.DRAFT.value,
         id="",
         patch_id=0,

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -54,6 +54,17 @@ def _read_variable_definition_file(file_path: Path) -> dict:
         return yaml.load(f)
 
 
+def _clean_values(data: dict):
+    """Recursively remove None values from nested dicts/lists and strip string values."""
+    if isinstance(data, dict):
+        return {k: _clean_values(v) for k, v in data.items() if v is not None}
+    if isinstance(data, list):
+        return [_clean_values(item) for item in data if item is not None]
+    if isinstance(data, str):
+        return data.strip()
+    return data
+
+
 def _read_file_to_model(
     file_path: PathLike[str] | None,
     model_class: type[T],
@@ -90,5 +101,4 @@ def _read_file_to_model(
     if model is None:
         msg = f"Could not read data from {file_path}"
         raise FileNotFoundError(msg)
-
-    return model
+    return _clean_values(model)

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -55,12 +55,12 @@ def _read_variable_definition_file(file_path: Path) -> dict:
         return yaml.load(f)
 
 
-def _clean_values(data: Any) -> Any:
+def _strip_strings_recursively(data: Any) -> Any:
     """Recursively strip string values from nested dicts/lists."""
     if isinstance(data, dict):
-        return {k: _clean_values(v) for k, v in data.items()}
+        return {k: _strip_strings_recursively(v) for k, v in data.items()}
     if isinstance(data, list):
-        return [_clean_values(item) for item in data]
+        return [_strip_strings_recursively(item) for item in data]
     if isinstance(data, str):
         return data.strip()
     return data
@@ -94,7 +94,7 @@ def _read_file_to_model(
             msg,
         ) from e
     raw_data = _read_variable_definition_file(file_path)
-    cleaned_data = _clean_values(raw_data)
+    cleaned_data = _strip_strings_recursively(raw_data)
 
     model = model_class.from_dict(  # type:ignore [attr-defined]
         cleaned_data

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -3,7 +3,6 @@
 import logging
 from os import PathLike
 from pathlib import Path
-from typing import Any
 from typing import TypeVar
 
 from pydantic import BaseModel
@@ -55,7 +54,7 @@ def _read_variable_definition_file(file_path: Path) -> dict:
         return yaml.load(f)
 
 
-def _clean_values(data: dict[str, Any]) -> dict[str, Any]:
+def _clean_values(data: dict) -> dict:
     """Recursively strip string values from nested dicts/lists."""
     if isinstance(data, dict):
         return {k: _clean_values(v) for k, v in data.items()}

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -56,7 +56,21 @@ def _read_variable_definition_file(file_path: Path) -> dict:
 
 
 def _strip_strings_recursively(data: Any) -> Any:
-    """Recursively strip string values from nested dicts/lists."""
+    """Recursively strip leading and trailing whitespace from string values in nested dicts/lists.
+
+    This function traverses the provided data, which may be a dictionary, list, or other types,
+    and applies the following logic:
+        - If the data is a dictionary, it recursively strips string values in all key-value pairs.
+        - If the data is a list, it recursively strips string values in all list elements.
+        - If the data is a string, it strips leading and trailing whitespace.
+        - Any other data types are returned unchanged.
+
+    Args:
+        data: The input data, which may include nested dictionaries, lists, or other types.
+
+    Returns:
+        Any: The processed data, with strings stripped of whitespace or unchanged if not a string.
+    """
     if isinstance(data, dict):
         return {k: _strip_strings_recursively(v) for k, v in data.items()}
     if isinstance(data, list):

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -17,6 +17,7 @@ from dapla_metadata.variable_definitions._utils.files import _get_current_time
 from dapla_metadata.variable_definitions._utils.files import (
     _model_to_yaml_with_comments,
 )
+from dapla_metadata.variable_definitions._utils.files import configure_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ def create_variable_yaml(
 
 def _read_variable_definition_file(file_path: Path) -> dict:
     yaml = YAML()
-
+    configure_yaml(yaml)
     logger.debug("Full path to variable definition file %s", file_path)
     logger.info("Reading from '%s'", file_path.name)
     with file_path.open(encoding="utf-8") as f:

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -3,6 +3,7 @@
 import logging
 from os import PathLike
 from pathlib import Path
+from typing import Any
 from typing import TypeVar
 
 from pydantic import BaseModel
@@ -54,7 +55,7 @@ def _read_variable_definition_file(file_path: Path) -> dict:
         return yaml.load(f)
 
 
-def _clean_values(data: dict) -> dict:
+def _clean_values(data: Any) -> Any:
     """Recursively strip string values from nested dicts/lists."""
     if isinstance(data, dict):
         return {k: _clean_values(v) for k, v in data.items()}

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -57,9 +57,7 @@ def _read_variable_definition_file(file_path: Path) -> dict:
 def _clean_values(data: dict):
     """Recursively remove None values from nested dicts/lists and strip string values."""
     if isinstance(data, dict):
-        return {
-            k: _clean_values(v) for k, v in data.items() if v not in (None, "", "None")
-        }
+        return {k: _clean_values(v) for k, v in data.items() if v is not None}
     if isinstance(data, list):
         return [_clean_values(item) for item in data if item is not None]
     if isinstance(data, str):
@@ -103,4 +101,4 @@ def _read_file_to_model(
     if model is None:
         msg = f"Could not read data from {file_path}"
         raise FileNotFoundError(msg)
-    return _clean_values(model)
+    return model

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -57,7 +57,9 @@ def _read_variable_definition_file(file_path: Path) -> dict:
 def _clean_values(data: dict):
     """Recursively remove None values from nested dicts/lists and strip string values."""
     if isinstance(data, dict):
-        return {k: _clean_values(v) for k, v in data.items() if v is not None}
+        return {
+            k: _clean_values(v) for k, v in data.items() if v not in (None, "", "None")
+        }
     if isinstance(data, list):
         return [_clean_values(item) for item in data if item is not None]
     if isinstance(data, str):

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -96,7 +96,9 @@ def _read_file_to_model(
     raw_data = _read_variable_definition_file(file_path)
     cleaned_data = _clean_values(raw_data)
 
-    model = model_class.from_dict(cleaned_data)
+    model = model_class.from_dict(  # type:ignore [attr-defined]
+        cleaned_data
+    )
 
     if model is None:
         msg = f"Could not read data from {file_path}"

--- a/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/variable_definition_files.py
@@ -57,9 +57,9 @@ def _read_variable_definition_file(file_path: Path) -> dict:
 def _clean_values(data: dict):
     """Recursively remove None values from nested dicts/lists and strip string values."""
     if isinstance(data, dict):
-        return {k: _clean_values(v) for k, v in data.items() if v is not None}
+        return {k: _clean_values(v) for k, v in data.items()}
     if isinstance(data, list):
-        return [_clean_values(item) for item in data if item is not None]
+        return [_clean_values(item) for item in data]
     if isinstance(data, str):
         return data.strip()
     return data
@@ -101,4 +101,4 @@ def _read_file_to_model(
     if model is None:
         msg = f"Could not read data from {file_path}"
         raise FileNotFoundError(msg)
-    return model
+    return _clean_values(model)

--- a/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
+++ b/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
@@ -37,18 +37,7 @@ subject_fields: |
     - "be"
 contains_special_categories_of_personal_data: |
   Viser om variabelen inneholder spesielt sensitive personopplysninger.
-  Kategorier:
-    - opplysninger om etnisk opprinnelse
-    - opplysninger om politisk oppfatning
-    - opplysninger om religion
-    - opplysninger om filosofisk overbevisning
-    - opplysninger om fagforeningsmedlemskap
-    - genetiske opplysninger
-    - biometriske opplysninger med det formål å entydig identifisere noen
-    - helseopplysninger
-    - opplysninger om seksuelle forhold
-    - opplysninger om seksuell legning
-  ref: https://lovdata.no/dokument/NL/lov/2018-06-15-38/KAPITTEL_gdpr-2#gdpr/a9
+  ref: https://statistics-norway.atlassian.net/wiki/spaces/MPD/pages/3009839199/VarDef+-+Krav+til+dokumentasjon+av+variabler#inneholder-s%C3%A6rlige-kategorier-av-personopplysninger%2FcontainsSpecialCategoriesOfPersonalData
   -------------------------
   >>> EKSEMPEL: true
 measurement_type: |
@@ -63,7 +52,7 @@ valid_from: |
 valid_until: |
   Datoen variabeldefinisjonens var gyldig t.o.m. Settes hvis definisjonen skal erstattet av en ny definisjon (med en ny gyldighetsperiode), eller variabelen ikke lenger skal brukes.
   -------------------------
-  >>> EKSEMPEL: 2025-10-23
+  >>> EKSEMPEL: 2024-10-23
 external_reference_uri:  |
   En peker (URI) til ekstern definisjon/dokumentasjon, f.eks. ei webside som er relevant for variabelen.
   -----------------------------------------------------

--- a/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
+++ b/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
@@ -52,6 +52,10 @@ external_reference_uri:  |
   Eksempel: "https://www.landbruksdirektoratet.com"
 comment: |
   Her kan en sette inn eventuelle tilleggsopplysninger som ikke hører hjemme i selve definisjonen. Variabelen “Landbakgrunn” har f.eks. merknaden “Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland”.
+  Eksempel:
+    comment:
+        nb: >-
+            Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland.
 related_variable_definition_uris: |
   Her kan en legge inn URIer til andre variabler som er relevante. Eksempelvis er variabelen “Inntekt etter skatt” en beregnet variabel der  “Yrkesinntekter” og “Kapitalinntekter” inngår i beregningen. En kan da legge inn deres URI-er i dette feltet.
   Eksempel: "https://example.com/"
@@ -60,7 +64,8 @@ contact: |
   Eksempel:
     contact:
       title:
-        nb: "Seksjonsleder"
+        nb: >-
+            Seksjonsleder
       email: leder@ssb.no
 variable_status: |
   Livssyklus for variabelen.

--- a/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
+++ b/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
@@ -59,11 +59,11 @@ measurement_type: |
 valid_from: |
   Datoen variabeldefinisjonen er gyldig f.o.m.
   -------------------------
-  >>> EKSEMPEL: 1999-01-11
+  >>> EKSEMPEL: 1999-01-30
 valid_until: |
   Datoen variabeldefinisjonens var gyldig t.o.m. Settes hvis definisjonen skal erstattet av en ny definisjon (med en ny gyldighetsperiode), eller variabelen ikke lenger skal brukes.
   -------------------------
-  >>> EKSEMPEL: 2025-10-03
+  >>> EKSEMPEL: 2025-10-23
 external_reference_uri:  |
   En peker (URI) til ekstern definisjon/dokumentasjon, f.eks. ei webside som er relevant for variabelen.
   -----------------------------------------------------

--- a/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
+++ b/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
@@ -1,25 +1,38 @@
 # --- Variabel definisjoner ---
 # ref: https://statistics-norway.atlassian.net/wiki/spaces/MPD/pages/3009839199/VarDef+-+Krav+til+dokumentasjon+av+variabler
 name: |
-  Variabelens navn. Dette skal ikke være en mer “teknisk” forkortelse, men et navn som er forståelig for mennesker, f.eks. “Lønnsinntekter”.
+  Variabelens navn. Dette skal ikke være en mer “teknisk” forkortelse, men et navn som er forståelig for mennesker.
+  -------------------------
+  >>> EKSEMPEL:
+  name:
+    nb: |-
+        Lønnsinntekter
 short_name: |
   Dette er variabelens kortnavn, som kan være en mer “teknisk” forkortelse, f.eks. wlonn (kortnavnet til Lønnsinntekter). Kortnavnet til en variabel i Vardef skal være unikt.
   Kravet til kortnavnet er at det kan inneholde a-z (kun små bokstaver), 0-9 og _ (understrek). Minimumslengden på kortnavnet er 2 tegn.  Bokstavene “æ”, “ø” og “å” kan ikke brukes. Disse anbefales erstattet med hhv. “ae”, “oe” og “aa"
 definition: |
   En definisjon skal beskrive hva variabelen betyr og være så kort og presis som mulig. Mer utfyllende opplysninger kan legges i Merknad-feltet.
+  -------------------------
+  >>> EKSEMPEL:
+  definition:
+    nb: |-
+        Yrkesinntekter, kapitalinntekter, skattepliktige og skattefrie overføringer, i løpet av kalenderåret.
 classification_reference: |
   ID av en klassifikasjon eller kodeliste fra KLASS som beskriver verdiene variabelen kan anta.
   For eksempel vil variabelen 'Sivilstand' ha klassifikasjon 'Standard for sivilstand' (kan vises på https://www.ssb.no/klass/klassifikasjoner/19 ) som har ID 19.
-  Eksempel: "19"
+  -------------------------
+  >>> EKSEMPEL: "19"
 unit_types: |
   Enhetstyper - enhetene som beskrives av denne variabelen. Variabelen “sivilstand” vil f.eks. ha enhetstypen person, mens f.eks. “Produsentpris for tjenester” vil ha både foretak og bedrift som enhetstyper siden variabelen kan beskrive begge.
   Verdier skal være koder fra: https://www.ssb.no/klass/klassifikasjoner/702.
-  Eksempel:
+  -------------------------
+  >>> EKSEMPEL:
     - "20"
 subject_fields: |
   Statistikkområder som variabelen brukes innenfor. For eksempel tilhører variabelen “Sivilstand” statistikkområdet “Befolkning”.
   Verdier skal være koder fra https://www.ssb.no/klass/klassifikasjoner/618.
-  Eksempel:
+  -------------------------
+  >>> EKSEMPEL:
     - "bf"
     - "be"
 contains_special_categories_of_personal_data: |
@@ -36,37 +49,46 @@ contains_special_categories_of_personal_data: |
     - opplysninger om seksuelle forhold
     - opplysninger om seksuell legning
   ref: https://lovdata.no/dokument/NL/lov/2018-06-15-38/KAPITTEL_gdpr-2#gdpr/a9
-  Eksempel: true
+  -------------------------
+  >>> EKSEMPEL: true
 measurement_type: |
   Måletype som en kvantitativ variabelen tilhører, f.eks.  valuta, areal osv.
   Verdien skal være en kode fra: https://www.ssb.no/klass/klassifikasjoner/303
-  Eksempel: "03"
+  -------------------------
+  >>> EKSEMPEL: "03"
 valid_from: |
   Datoen variabeldefinisjonen er gyldig f.o.m.
-  Eksempel: 1999-01-11
+  -------------------------
+  >>> EKSEMPEL: 1999-01-11
 valid_until: |
   Datoen variabeldefinisjonens var gyldig t.o.m. Settes hvis definisjonen skal erstattet av en ny definisjon (med en ny gyldighetsperiode), eller variabelen ikke lenger skal brukes.
-  Eksempel: 2025-10-03
+  -------------------------
+  >>> EKSEMPEL: 2025-10-03
 external_reference_uri:  |
   En peker (URI) til ekstern definisjon/dokumentasjon, f.eks. ei webside som er relevant for variabelen.
-  Eksempel: "https://www.landbruksdirektoratet.com"
+  -----------------------------------------------------
+  >>> EKSEMPEL: "https://www.landbruksdirektoratet.com"
 comment: |
   Her kan en sette inn eventuelle tilleggsopplysninger som ikke hører hjemme i selve definisjonen. Variabelen “Landbakgrunn” har f.eks. merknaden “Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland”.
-  Eksempel:
-    comment:
-        nb: >-
-            Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland.
+  -----------------------------------------------------------------------------------------------
+  >>> EKSEMPEL:
+  comment:
+    nb: |-
+        Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland.
 related_variable_definition_uris: |
   Her kan en legge inn URIer til andre variabler som er relevante. Eksempelvis er variabelen “Inntekt etter skatt” en beregnet variabel der  “Yrkesinntekter” og “Kapitalinntekter” inngår i beregningen. En kan da legge inn deres URI-er i dette feltet.
-  Eksempel: "https://example.com/"
+  -------------------------
+  >>> EKSEMPEL:
+    - "https://example.com/"
 contact: |
   Her dokumenterer en navn og epost for person eller gruppe som kan svare på spørsmål.
-  Eksempel:
-    contact:
-      title:
-        nb: >-
-            Seksjonsleder
-      email: leder@ssb.no
+  -------------------------
+  >>> EKSEMPEL:
+  contact:
+    title:
+      nb: |-
+          Seksjonsleder
+    email: leder@ssb.no
 variable_status: |
   Livssyklus for variabelen.
 id: |

--- a/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
+++ b/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
@@ -5,7 +5,7 @@ name: |
   -------------------------
   >>> EKSEMPEL:
   name:
-    nb: |-
+    nb: >-
         Lønnsinntekter
 short_name: |
   Dette er variabelens kortnavn, som kan være en mer “teknisk” forkortelse, f.eks. wlonn (kortnavnet til Lønnsinntekter). Kortnavnet til en variabel i Vardef skal være unikt.
@@ -15,7 +15,7 @@ definition: |
   -------------------------
   >>> EKSEMPEL:
   definition:
-    nb: |-
+    nb: >-
         Yrkesinntekter, kapitalinntekter, skattepliktige og skattefrie overføringer, i løpet av kalenderåret.
 classification_reference: |
   ID av en klassifikasjon eller kodeliste fra KLASS som beskriver verdiene variabelen kan anta.
@@ -86,7 +86,7 @@ contact: |
   >>> EKSEMPEL:
   contact:
     title:
-      nb: |-
+      nb: >-
           Seksjonsleder
     email: leder@ssb.no
 variable_status: |

--- a/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
+++ b/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
@@ -5,7 +5,7 @@ name: |
   -------------------------
   >>> EKSEMPEL:
   name:
-    nb: >-
+    nb: |-
         Lønnsinntekter
 short_name: |
   Dette er variabelens kortnavn, som kan være en mer “teknisk” forkortelse, f.eks. wlonn (kortnavnet til Lønnsinntekter). Kortnavnet til en variabel i Vardef skal være unikt.
@@ -15,7 +15,7 @@ definition: |
   -------------------------
   >>> EKSEMPEL:
   definition:
-    nb: >-
+    nb: |-
         Yrkesinntekter, kapitalinntekter, skattepliktige og skattefrie overføringer, i løpet av kalenderåret.
 classification_reference: |
   ID av en klassifikasjon eller kodeliste fra KLASS som beskriver verdiene variabelen kan anta.
@@ -86,7 +86,7 @@ contact: |
   >>> EKSEMPEL:
   contact:
     title:
-      nb: >-
+      nb: |-
           Seksjonsleder
     email: leder@ssb.no
 variable_status: |

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -389,10 +389,10 @@ definition:
         test
 classification_reference: "91"
 unit_types:
-- "01"
+    - "01"
 subject_fields:
-- "a"
-- "b"
+    - "a"
+    - "b"
 contains_special_categories_of_personal_data: true
 variable_status: PUBLISHED_EXTERNAL
 measurement_type: "test"
@@ -407,11 +407,11 @@ comment:
     en: |-
         test
 related_variable_definition_uris:
-- "http://www.example.com"
+    - "http://www.example.com"
 owner:
     team: "my_team"
     groups:
-    - "my_team_developers"
+        - "my_team_developers"
 contact:
     title:
         nb: |-

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -373,19 +373,19 @@ def test_str(variable_definition):
         == """id: "wypvb3wd"
 patch_id: 1
 name:
-    nb: >-
+    nb: |-
         test
-    nn: >-
+    nn: |-
         test
-    en: >-
+    en: |-
         test
 short_name: "var_test"
 definition:
-    nb: >-
+    nb: |-
         test
-    nn: >-
+    nn: |-
         test
-    en: >-
+    en: |-
         test
 classification_reference: "91"
 unit_types:
@@ -400,11 +400,11 @@ valid_from: '2024-11-01'
 valid_until:
 external_reference_uri: "http://www.example.com"
 comment:
-    nb: >-
+    nb: |-
         test
-    nn: >-
+    nn: |-
         test
-    en: >-
+    en: |-
         test
 related_variable_definition_uris:
 - "http://www.example.com"
@@ -414,11 +414,11 @@ owner:
     - "my_team_developers"
 contact:
     title:
-        nb: >-
+        nb: |-
             test
-        nn: >-
+        nn: |-
             test
-        en: >-
+        en: |-
             test
     email: me@example.com
 created_at: '2024-11-01T00:00:00'

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -373,19 +373,19 @@ def test_str(variable_definition):
         == """id: "wypvb3wd"
 patch_id: 1
 name:
-    nb: >-
+    nb: |-
         test
-    nn: >-
+    nn: |-
         test
-    en: >-
+    en: |-
         test
 short_name: "var_test"
 definition:
-    nb: >-
+    nb: |-
         test
-    nn: >-
+    nn: |-
         test
-    en: >-
+    en: |-
         test
 classification_reference: "91"
 unit_types:
@@ -414,11 +414,11 @@ owner:
     - "my_team_developers"
 contact:
     title:
-        nb: >-
+        nb: |-
             test
-        nn: >-
+        nn: |-
             test
-        en: >-
+        en: |-
             test
     email: me@example.com
 created_at: '2024-11-01T00:00:00'

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -373,19 +373,19 @@ def test_str(variable_definition):
         == """id: "wypvb3wd"
 patch_id: 1
 name:
-    nb: |-
+    nb: >-
         test
-    nn: |-
+    nn: >-
         test
-    en: |-
+    en: >-
         test
 short_name: "var_test"
 definition:
-    nb: |-
+    nb: >-
         test
-    nn: |-
+    nn: >-
         test
-    en: |-
+    en: >-
         test
 classification_reference: "91"
 unit_types:
@@ -414,11 +414,11 @@ owner:
     - "my_team_developers"
 contact:
     title:
-        nb: |-
+        nb: >-
             test
-        nn: |-
+        nn: >-
             test
-        en: |-
+        en: >-
             test
     email: me@example.com
 created_at: '2024-11-01T00:00:00'

--- a/tests/variable_definitions/test_variable_definition_files.py
+++ b/tests/variable_definitions/test_variable_definition_files.py
@@ -55,6 +55,7 @@ def test_yaml_content_default_values(work_folder_defaults: Path):
 
     assert parsed_yaml["variable_status"] == "DRAFT"
     assert parsed_yaml["owner"]["team"] == "default team"
+    assert parsed_yaml["name"]["nn"] is None
 
 
 def test_yaml_content_saved_values(work_folder_variable_definition: Path) -> None:


### PR DESCRIPTION
**Improve user experience yaml file**

Use block type on multi language fields:
- Can save special characters like ":"
- Save newlines and indentation etc
- Strip leading/trailing whitespace

Reduce use of placeholder text template:
- Decrease risk for saving placeholder text
- Examples are preserved and better for demonstrating usage/type/values etc

Comments:
- Distinguish more clearly between explanation and example

Yaml syntax highlighting will not be fully correct, but the values are saved correctly:

![Screenshot 2025-04-10 at 14 15 51](https://github.com/user-attachments/assets/97fdd88e-d963-4811-bd43-be72f981fd5a)

![Screenshot 2025-04-10 at 14 14 47](https://github.com/user-attachments/assets/d0ff4b36-573d-4737-9afe-157f8dbfd0f0)

ref: https://statistics-norway.atlassian.net/browse/DPMETA-846