### PR TITLE
Field requirement status in yaml

### DIFF
--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import cast
 
 import pytz
@@ -118,6 +119,15 @@ def _get_variable_definitions_dir():
     return folder_path
 
 
+def _set_field_requirement(field_name: str, field: Any) -> str | None:
+    """Determine the field requirement status."""
+    if field_name not in MACHINE_GENERATED_FIELDS:
+        if field.is_required() or field_name == VARIABLE_STATUS_FIELD_NAME:
+            return REQUIRED_FIELD
+        return OPTIONAL_FIELD
+    return None
+
+
 def _populate_commented_map(
     field_name: str,
     value: str,
@@ -131,12 +141,12 @@ def _populate_commented_map(
         JsonDict,
         field.json_schema_extra,
     )[NORWEGIAN_DESCRIPTIONS]
+    field_requirement: str = _set_field_requirement(field_name, field)
     if description is not None:
         new_description = (
-            "\n"
-            + (REQUIRED_FIELD if field.is_required() else OPTIONAL_FIELD)
-            + "\n"
-            + str(description)
+            ("\n" + field_requirement + "\n" + str(description))
+            if field_requirement
+            else ("\n" + str(description))
         )
         commented_map.yaml_set_comment_before_after_key(
             field_name,

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -197,7 +197,7 @@ def configure_yaml(yaml: YAML) -> YAML:
     yaml.default_flow_style = False  # Ensures pretty YAML formatting block style
     yaml.allow_unicode = True  # Support special characters
     yaml.preserve_quotes = True
-    yaml.width = 180  # wrap long lines
+    yaml.width = 120  # wrap long lines
     yaml.indent(
         mapping=4,
         sequence=6,

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -141,7 +141,7 @@ def _populate_commented_map(
         JsonDict,
         field.json_schema_extra,
     )[NORWEGIAN_DESCRIPTIONS]
-    field_requirement: str = _set_field_requirement(field_name, field)
+    field_requirement: str | None = _set_field_requirement(field_name, field)
     if description is not None:
         new_description = (
             ("\n" + field_requirement + "\n" + str(description))

--- a/src/dapla_metadata/variable_definitions/_utils/files.py
+++ b/src/dapla_metadata/variable_definitions/_utils/files.py
@@ -197,7 +197,7 @@ def configure_yaml(yaml: YAML) -> YAML:
     yaml.default_flow_style = False  # Ensures pretty YAML formatting block style
     yaml.allow_unicode = True  # Support special characters
     yaml.preserve_quotes = True
-    yaml.width = 120  # wrap long lines
+    yaml.width = 4096  # prevent wrapping lines
     yaml.indent(
         mapping=4,
         sequence=6,

--- a/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
+++ b/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
@@ -37,7 +37,6 @@ subject_fields: |
     - "be"
 contains_special_categories_of_personal_data: |
   Viser om variabelen inneholder spesielt sensitive personopplysninger.
-  ref: https://statistics-norway.atlassian.net/wiki/spaces/MPD/pages/3009839199/VarDef+-+Krav+til+dokumentasjon+av+variabler#inneholder-s%C3%A6rlige-kategorier-av-personopplysninger%2FcontainsSpecialCategoriesOfPersonalData
   -------------------------
   >>> EKSEMPEL: true
 measurement_type: |

--- a/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
+++ b/src/dapla_metadata/variable_definitions/resources/vardef_model_descriptions_nb.yaml
@@ -9,7 +9,8 @@ name: |
         Lønnsinntekter
 short_name: |
   Dette er variabelens kortnavn, som kan være en mer “teknisk” forkortelse, f.eks. wlonn (kortnavnet til Lønnsinntekter). Kortnavnet til en variabel i Vardef skal være unikt.
-  Kravet til kortnavnet er at det kan inneholde a-z (kun små bokstaver), 0-9 og _ (understrek). Minimumslengden på kortnavnet er 2 tegn.  Bokstavene “æ”, “ø” og “å” kan ikke brukes. Disse anbefales erstattet med hhv. “ae”, “oe” og “aa"
+  Kravet til kortnavnet er at det kan inneholde a-z (kun små bokstaver), 0-9 og _ (understrek). Minimumslengden på kortnavnet er 2 tegn.
+  Bokstavene “æ”, “ø” og “å” kan ikke brukes. Disse anbefales erstattet med hhv. “ae”, “oe” og “aa"
 definition: |
   En definisjon skal beskrive hva variabelen betyr og være så kort og presis som mulig. Mer utfyllende opplysninger kan legges i Merknad-feltet.
   -------------------------
@@ -23,7 +24,8 @@ classification_reference: |
   -------------------------
   >>> EKSEMPEL: "19"
 unit_types: |
-  Enhetstyper - enhetene som beskrives av denne variabelen. Variabelen “sivilstand” vil f.eks. ha enhetstypen person, mens f.eks. “Produsentpris for tjenester” vil ha både foretak og bedrift som enhetstyper siden variabelen kan beskrive begge.
+  Enhetstyper - enhetene som beskrives av denne variabelen. Variabelen “sivilstand” vil f.eks. ha enhetstypen person,
+  mens f.eks. “Produsentpris for tjenester” vil ha både foretak og bedrift som enhetstyper siden variabelen kan beskrive begge.
   Verdier skal være koder fra: https://www.ssb.no/klass/klassifikasjoner/702.
   -------------------------
   >>> EKSEMPEL:
@@ -57,14 +59,16 @@ external_reference_uri:  |
   -----------------------------------------------------
   >>> EKSEMPEL: "https://www.landbruksdirektoratet.com"
 comment: |
-  Her kan en sette inn eventuelle tilleggsopplysninger som ikke hører hjemme i selve definisjonen. Variabelen “Landbakgrunn” har f.eks. merknaden “Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland”.
+  Her kan en sette inn eventuelle tilleggsopplysninger som ikke hører hjemme i selve definisjonen.
+  Variabelen “Landbakgrunn” har f.eks. merknaden “Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland”.
   -----------------------------------------------------------------------------------------------
   >>> EKSEMPEL:
   comment:
     nb: |-
         Fra og med 1.1.2003 ble definisjon endret til også å trekke inn besteforeldrenes fødeland.
 related_variable_definition_uris: |
-  Her kan en legge inn URIer til andre variabler som er relevante. Eksempelvis er variabelen “Inntekt etter skatt” en beregnet variabel der  “Yrkesinntekter” og “Kapitalinntekter” inngår i beregningen. En kan da legge inn deres URI-er i dette feltet.
+  Her kan en legge inn URIer til andre variabler som er relevante. Eksempelvis er variabelen “Inntekt etter skatt” en beregnet variabel der  “Yrkesinntekter” og “Kapitalinntekter” inngår i beregningen.
+  En kan da legge inn deres URI-er i dette feltet.
   -------------------------
   >>> EKSEMPEL:
     - "https://example.com/"


### PR DESCRIPTION
Setting either "Obligatorisk felt" or "Valgfritt felt" in Yaml files was based on field info `is_required`.
But this value could be wrong for fields with default value.

- Set `variable_status` as "Obligatorisk felt"
- Remove requirement info entirely for machine generated fields 

Also:
- Set yaml width to "4096" to prevent wrapping lines
- Adjust descriptions 
