### PR TITLE
Support validation of required fields on existing metadata document

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,6 @@
   "evenBetterToml.formatter.columnWidth": 120,
   "evenBetterToml.schema.associations": {
     "pyproject.toml": "pyproject"
-  }
+  },
+  "python-envs.defaultEnvManager": "ms-python.python:system"
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -206,7 +206,7 @@ def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     session.install(".")
     session.install(*TESTS_SESSIONS_DEPENDENCIES, "typeguard")
-    session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
+    session.run("pytest", f"--typeguard-packages={package}.datasets", *session.posargs)
 
 
 @session(python="3.12")

--- a/noxfile.py
+++ b/noxfile.py
@@ -206,7 +206,7 @@ def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     session.install(".")
     session.install(*TESTS_SESSIONS_DEPENDENCIES, "typeguard")
-    session.run("pytest", f"--typeguard-packages={package}.datasets", *session.posargs)
+    session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 
 @session(python="3.12")

--- a/poetry.lock
+++ b/poetry.lock
@@ -321,104 +321,104 @@ files = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.1"
+version = "3.4.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-win32.whl", hash = "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-win32.whl", hash = "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f30bf9fd9be89ecb2360c7d94a711f00c09b976258846efe40db3d05828e8089"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:97f68b8d6831127e4787ad15e6757232e14e12060bec17091b85eb1486b91d8d"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7974a0b5ecd505609e3b19742b60cee7aa2aa2fb3151bc917e6e2646d7667dcf"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:311f30128d7d333eebd7896965bfcfbd0065f1716ec92bd5638d7748eb6f936a"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:7d053096f67cd1241601111b698f5cad775f97ab25d81567d3f59219b5f1adbd"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:807f52c1f798eef6cf26beb819eeb8819b1622ddfeef9d0977a8502d4db6d534"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:dccbe65bd2f7f7ec22c4ff99ed56faa1e9f785482b9bbd7c717e26fd723a1d1e"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_s390x.whl", hash = "sha256:2fb9bd477fdea8684f78791a6de97a953c51831ee2981f8e4f583ff3b9d9687e"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:01732659ba9b5b873fc117534143e4feefecf3b2078b0a6a2e925271bb6f4cfa"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-win32.whl", hash = "sha256:7a4f97a081603d2050bfaffdefa5b02a9ec823f8348a572e39032caa8404a487"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7b1bef6280950ee6c177b326508f86cad7ad4dff12454483b51d8b7d673a2c5d"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ecddf25bee22fe4fe3737a399d0d177d72bc22be6913acfab364b40bce1ba83c"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c60ca7339acd497a55b0ea5d506b2a2612afb2826560416f6894e8b5770d4a9"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b7b2d86dd06bfc2ade3312a83a5c364c7ec2e3498f8734282c6c3d4b07b346b8"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd78cfcda14a1ef52584dbb008f7ac81c1328c0f58184bf9a84c49c605002da6"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e27f48bcd0957c6d4cb9d6fa6b61d192d0b13d5ef563e5f2ae35feafc0d179c"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01ad647cdd609225c5350561d084b42ddf732f4eeefe6e678765636791e78b9a"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:619a609aa74ae43d90ed2e89bdd784765de0a25ca761b93e196d938b8fd1dbbd"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:89149166622f4db9b4b6a449256291dc87a99ee53151c74cbd82a53c8c2f6ccd"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:7709f51f5f7c853f0fb938bcd3bc59cdfdc5203635ffd18bf354f6967ea0f824"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:345b0426edd4e18138d6528aed636de7a9ed169b4aaf9d61a8c19e39d26838ca"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0907f11d019260cdc3f94fbdb23ff9125f6b5d1039b76003b5b0ac9d6a6c9d5b"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-win32.whl", hash = "sha256:ea0d8d539afa5eb2728aa1932a988a9a7af94f18582ffae4bc10b3fbdad0626e"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:329ce159e82018d646c7ac45b01a430369d526569ec08516081727a20e9e4af4"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b97e690a2118911e39b4042088092771b4ae3fc3aa86518f84b8cf6888dbdb41"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78baa6d91634dfb69ec52a463534bc0df05dbd546209b79a3880a34487f4b84f"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a2bc9f351a75ef49d664206d51f8e5ede9da246602dc2d2726837620ea034b2"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75832c08354f595c760a804588b9357d34ec00ba1c940c15e31e96d902093770"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0af291f4fe114be0280cdd29d533696a77b5b49cfde5467176ecab32353395c4"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2a75d49014d118e4198bcee5ee0a6f25856b29b12dbf7cd012791f8a6cc5c496"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363e2f92b0f0174b2f8238240a1a30142e3db7b957a5dd5689b0e75fb717cc78"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:ab36c8eb7e454e34e60eb55ca5d241a5d18b2c6244f6827a30e451c42410b5f7"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4c0907b1928a36d5a998d72d64d8eaa7244989f7aaaf947500d3a800c83a3fd6"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:04432ad9479fa40ec0f387795ddad4437a2b50417c69fa275e212933519ff294"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-win32.whl", hash = "sha256:3bed14e9c89dcb10e8f3a29f9ccac4955aebe93c71ae803af79265c9ca5644c5"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765"},
-    {file = "charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85"},
-    {file = "charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9cbfacf36cb0ec2897ce0ebc5d08ca44213af24265bd56eca54bee7923c48fd6"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18dd2e350387c87dabe711b86f83c9c78af772c748904d372ade190b5c7c9d4d"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8075c35cd58273fee266c58c0c9b670947c19df5fb98e7b66710e04ad4e9ff86"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5bf4545e3b962767e5c06fe1738f951f77d27967cb2caa64c28be7c4563e162c"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a6ab32f7210554a96cd9e33abe3ddd86732beeafc7a28e9955cdf22ffadbab0"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b33de11b92e9f75a2b545d6e9b6f37e398d86c3e9e9653c4864eb7e89c5773ef"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8755483f3c00d6c9a77f490c17e6ab0c8729e39e6390328e42521ef175380ae6"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:68a328e5f55ec37c57f19ebb1fdc56a248db2e3e9ad769919a58672958e8f366"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:21b2899062867b0e1fde9b724f8aecb1af14f2778d69aacd1a5a1853a597a5db"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-win32.whl", hash = "sha256:e8082b26888e2f8b36a042a58307d5b917ef2b1cacab921ad3323ef91901c71a"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:f69a27e45c43520f5487f27627059b64aaf160415589230992cec34c5e18a509"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:be1e352acbe3c78727a16a455126d9ff83ea2dfdcbc83148d2982305a04714c2"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa88ca0b1932e93f2d961bf3addbb2db902198dca337d88c89e1559e066e7645"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d524ba3f1581b35c03cb42beebab4a13e6cdad7b36246bd22541fa585a56cccd"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28a1005facc94196e1fb3e82a3d442a9d9110b8434fc1ded7a24a2983c9888d8"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f5d9ed7f254402c9e7d35d2f5972c9bbea9040e99cd2861bd77dc68263277c7"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:efd387a49825780ff861998cd959767800d54f8308936b21025326de4b5a42b9"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f0aa37f3c979cf2546b73e8222bbfa3dc07a641585340179d768068e3455e544"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e70e990b2137b29dc5564715de1e12701815dacc1d056308e2b17e9095372a82"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:0c8c57f84ccfc871a48a47321cfa49ae1df56cd1d965a09abe84066f6853b9c0"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6b66f92b17849b85cad91259efc341dce9c1af48e2173bf38a85c6329f1033e5"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-win32.whl", hash = "sha256:daac4765328a919a805fa5e2720f3e94767abd632ae410a9062dff5412bae65a"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:e53efc7c7cee4c1e70661e2e112ca46a575f90ed9ae3fef200f2a25e954f4b28"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cad5f45b3146325bb38d6855642f6fd609c3f7cad4dbaf75549bf3b904d3184"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2680962a4848b3c4f155dc2ee64505a9c57186d0d56b43123b17ca3de18f0fa"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:36b31da18b8890a76ec181c3cf44326bf2c48e36d393ca1b72b3f484113ea344"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4074c5a429281bf056ddd4c5d3b740ebca4d43ffffe2ef4bf4d2d05114299da"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c9e36a97bee9b86ef9a1cf7bb96747eb7a15c2f22bdb5b516434b00f2a599f02"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:1b1bde144d98e446b056ef98e59c256e9294f6b74d7af6846bf5ffdafd687a7d"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:915f3849a011c1f593ab99092f3cecfcb4d65d8feb4a64cf1bf2d22074dc0ec4"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_s390x.whl", hash = "sha256:25a23ea5c7edc53e0f29bae2c44fcb5a1aa10591aae107f2a2b2583a9c5cbc64"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:770cab594ecf99ae64c236bc9ee3439c3f46be49796e265ce0cc8bc17b10294f"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-win32.whl", hash = "sha256:6a0289e4589e8bdfef02a80478f1dfcb14f0ab696b5a00e1f4b8a14a307a3c58"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6fc1f5b51fa4cecaa18f2bd7a003f3dd039dd615cd69a2afd6d3b19aed6775f2"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:76af085e67e56c8816c3ccf256ebd136def2ed9654525348cfa744b6802b69eb"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e45ba65510e2647721e35323d6ef54c7974959f6081b58d4ef5d87c60c84919a"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:046595208aae0120559a67693ecc65dd75d46f7bf687f159127046628178dc45"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75d10d37a47afee94919c4fab4c22b9bc2a8bf7d4f46f87363bcf0573f3ff4f5"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6333b3aa5a12c26b2a4d4e7335a28f1475e0e5e17d69d55141ee3cab736f66d1"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8323a9b031aa0393768b87f04b4164a40037fb2a3c11ac06a03ffecd3618027"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:24498ba8ed6c2e0b56d4acbf83f2d989720a93b41d712ebd4f4979660db4417b"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:844da2b5728b5ce0e32d863af26f32b5ce61bc4273a9c720a9f3aa9df73b1455"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:65c981bdbd3f57670af8b59777cbfae75364b483fa8a9f420f08094531d54a01"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:3c21d4fca343c805a52c0c78edc01e3477f6dd1ad7c47653241cf2a206d4fc58"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dc7039885fa1baf9be153a0626e337aa7ec8bf96b0128605fb0d77788ddc1681"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-win32.whl", hash = "sha256:8272b73e1c5603666618805fe821edba66892e2870058c94c53147602eab29c7"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:70f7172939fdf8790425ba31915bfbe8335030f05b9913d7ae00a87d4395620a"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50bf98d5e563b83cc29471fa114366e6806bc06bc7a25fd59641e41445327836"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:721c76e84fe669be19c5791da68232ca2e05ba5185575086e384352e2c309597"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3daeac64d5b371dea99714f08ffc2c208522ec6b06fbc7866a450dd446f5c0f"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:aaf27faa992bfee0264dc1f03f4c75e9fcdda66a519db6b957a3f826e285cf12"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:eb30abc20df9ab0814b5a2524f23d75dcf83cde762c161917a2b4b7b55b1e518"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:c72fbbe68c6f32f251bdc08b8611c7b3060612236e960ef848e0a517ddbe76c5"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-win32.whl", hash = "sha256:43e0933a0eff183ee85833f341ec567c0980dae57c464d8a508e1b2ceb336471"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e"},
+    {file = "charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0"},
+    {file = "charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63"},
 ]
 
 [[package]]
@@ -915,14 +915,14 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-auth"
-version = "2.39.0"
+version = "2.40.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "google_auth-2.39.0-py2.py3-none-any.whl", hash = "sha256:0150b6711e97fb9f52fe599f55648950cc4540015565d8fbb31be2ad6e1548a2"},
-    {file = "google_auth-2.39.0.tar.gz", hash = "sha256:73222d43cdc35a3aeacbfdcaf73142a97839f10de930550d89ebfe1d0a00cde7"},
+    {file = "google_auth-2.40.0-py2.py3-none-any.whl", hash = "sha256:dc3a5078acb1043c3e43685c22d628afe40af8559cf561de388e0c939280fcc8"},
+    {file = "google_auth-2.40.0.tar.gz", hash = "sha256:c277cf39f7c192d8540eb6331c08b5a0796e8041af8343ae73dd6b269732ca6c"},
 ]
 
 [package.dependencies]
@@ -1324,20 +1324,20 @@ test-extra = ["curio", "ipython[test]", "jupyter_ai", "matplotlib (!=3.2.0)", "n
 
 [[package]]
 name = "ipywidgets"
-version = "8.1.6"
+version = "8.1.7"
 description = "Jupyter interactive widgets"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "ipywidgets-8.1.6-py3-none-any.whl", hash = "sha256:446e7630a1d025bdc7635e1169fcc06f2ce33b5bd41c2003edeb4a47c8d4bbb1"},
-    {file = "ipywidgets-8.1.6.tar.gz", hash = "sha256:d8ace49c66f14419fc66071371b99d01bed230bbc15d8a60233b18bfbd782851"},
+    {file = "ipywidgets-8.1.7-py3-none-any.whl", hash = "sha256:764f2602d25471c213919b8a1997df04bef869251db4ca8efba1b76b1bd9f7bb"},
+    {file = "ipywidgets-8.1.7.tar.gz", hash = "sha256:15f1ac050b9ccbefd45dccfbb2ef6bed0029d8278682d569d71b8dd96bee0376"},
 ]
 
 [package.dependencies]
 comm = ">=0.1.3"
 ipython = ">=6.1.0"
-jupyterlab_widgets = ">=3.0.14,<3.1.0"
+jupyterlab_widgets = ">=3.0.15,<3.1.0"
 traitlets = ">=4.3.1"
 widgetsnbextension = ">=4.0.14,<4.1.0"
 
@@ -1472,14 +1472,14 @@ test = ["ipykernel", "pre-commit", "pytest (<8)", "pytest-cov", "pytest-timeout"
 
 [[package]]
 name = "jupyterlab-widgets"
-version = "3.0.14"
+version = "3.0.15"
 description = "Jupyter interactive widgets for JupyterLab"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "jupyterlab_widgets-3.0.14-py3-none-any.whl", hash = "sha256:54c33e3306b7fca139d165d6190dc6c0627aafa5d14adfc974a4e9a3d26cb703"},
-    {file = "jupyterlab_widgets-3.0.14.tar.gz", hash = "sha256:bad03e59546869f026e537e0d170e454259e6dc7048e14041707ca31e523c8a1"},
+    {file = "jupyterlab_widgets-3.0.15-py3-none-any.whl", hash = "sha256:d59023d7d7ef71400d51e6fee9a88867f6e65e10a4201605d2d7f3e8f012a31c"},
+    {file = "jupyterlab_widgets-3.0.15.tar.gz", hash = "sha256:2920888a0c2922351a9202817957a68c07d99673504d6cd37345299e971bb08b"},
 ]
 
 [[package]]
@@ -3013,14 +3013,14 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "redis"
-version = "5.2.1"
+version = "6.0.0"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4"},
-    {file = "redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f"},
+    {file = "redis-6.0.0-py3-none-any.whl", hash = "sha256:a2e040aee2cdd947be1fa3a32e35a956cd839cc4c1dbbe4b2cdee5b9623fd27c"},
+    {file = "redis-6.0.0.tar.gz", hash = "sha256:5446780d2425b787ed89c91ddbfa1be6d32370a636c8fdb687f11b1c26c1fa88"},
 ]
 
 [package.dependencies]
@@ -3028,7 +3028,8 @@ async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\
 
 [package.extras]
 hiredis = ["hiredis (>=3.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
+jwt = ["pyjwt (>=2.9.0,<2.10.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
 
 [[package]]
 name = "requests"
@@ -3290,14 +3291,14 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "80.1.0"
+version = "80.3.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "setuptools-80.1.0-py3-none-any.whl", hash = "sha256:ea0e7655c05b74819f82e76e11a85b31779fee7c4969e82f72bab0664e8317e4"},
-    {file = "setuptools-80.1.0.tar.gz", hash = "sha256:2e308396e1d83de287ada2c2fd6e64286008fe6aca5008e0b6a8cb0e2c86eedd"},
+    {file = "setuptools-80.3.1-py3-none-any.whl", hash = "sha256:ea8e00d7992054c4c592aeb892f6ad51fe1b4d90cc6947cc45c45717c40ec537"},
+    {file = "setuptools-80.3.1.tar.gz", hash = "sha256:31e2c58dbb67c99c289f51c16d899afedae292b978f8051efaf6262d8212f927"},
 ]
 
 [package.extras]
@@ -3488,15 +3489,15 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "defusedxml (>=0.7.1)",
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.1.0"
+version = "3.2.0"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 optional = false
 python-versions = ">=3.11"
 groups = ["dev"]
 markers = "python_version >= \"3.11\""
 files = [
-    {file = "sphinx_autodoc_typehints-3.1.0-py3-none-any.whl", hash = "sha256:67bdee7e27ba943976ce92ebc5647a976a7a08f9f689a826c54617b96a423913"},
-    {file = "sphinx_autodoc_typehints-3.1.0.tar.gz", hash = "sha256:a6b7b0b6df0a380783ce5b29150c2d30352746f027a3e294d37183995d3f23ed"},
+    {file = "sphinx_autodoc_typehints-3.2.0-py3-none-any.whl", hash = "sha256:884b39be23b1d884dcc825d4680c9c6357a476936e3b381a67ae80091984eb49"},
+    {file = "sphinx_autodoc_typehints-3.2.0.tar.gz", hash = "sha256:107ac98bc8b4837202c88c0736d59d6da44076e65a0d7d7d543a78631f662a9b"},
 ]
 
 [package.dependencies]
@@ -3643,14 +3644,14 @@ test = ["pytest"]
 
 [[package]]
 name = "ssb-datadoc-model"
-version = "6.0.0"
+version = "6.1.0"
 description = "Data Model for use in Statistics Norway's Metadata system"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "ssb_datadoc_model-6.0.0-py3-none-any.whl", hash = "sha256:be278972357a2e424e1a396e4ccdeb42a454a67489d772de5009938b3dee1b6d"},
-    {file = "ssb_datadoc_model-6.0.0.tar.gz", hash = "sha256:b4d97fbdff1f423d7fc31cbf7881b63b722777b5c8fbfce5f0af1f5d6671fd36"},
+    {file = "ssb_datadoc_model-6.1.0-py3-none-any.whl", hash = "sha256:28cd1ca1de2648f9d41c01fa2e4e20acd1ec717e052f67b2c31f616142e68a87"},
+    {file = "ssb_datadoc_model-6.1.0.tar.gz", hash = "sha256:875df34e05bd352960e4a0fa5e9445938451638b1121a35a2723758f110542a2"},
 ]
 
 [package.dependencies]
@@ -3989,14 +3990,14 @@ urllib3 = ">=2"
 
 [[package]]
 name = "types-setuptools"
-version = "80.0.0.20250429"
+version = "80.3.0.20250505"
 description = "Typing stubs for setuptools"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "types_setuptools-80.0.0.20250429-py3-none-any.whl", hash = "sha256:9bbcdcea88d1fda4b0f1371488333f606c78a8b10154a42530ed926ecf3242cb"},
-    {file = "types_setuptools-80.0.0.20250429.tar.gz", hash = "sha256:a4de44f1110f531e7f9453d72999437a1caa6052609e2c7c859dd6613ab0d593"},
+    {file = "types_setuptools-80.3.0.20250505-py3-none-any.whl", hash = "sha256:117c86a82367306388b55310d04da807ff4c3ecdf769656a5fdc0fdd06a2c1b6"},
+    {file = "types_setuptools-80.3.0.20250505.tar.gz", hash = "sha256:5fd3d34b8fa3441d68d010fef95e232d1e48f3f5cb578f3477b7aae4f8374502"},
 ]
 
 [package.dependencies]
@@ -4081,14 +4082,14 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 
 [[package]]
 name = "virtualenv"
-version = "20.30.0"
+version = "20.31.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-20.30.0-py3-none-any.whl", hash = "sha256:e34302959180fca3af42d1800df014b35019490b119eba981af27f2fa486e5d6"},
-    {file = "virtualenv-20.30.0.tar.gz", hash = "sha256:800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8"},
+    {file = "virtualenv-20.31.1-py3-none-any.whl", hash = "sha256:f448cd2f1604c831afb9ea238021060be2c0edbcad8eb0a4e8b4e14ff11a5482"},
+    {file = "virtualenv-20.31.1.tar.gz", hash = "sha256:65442939608aeebb9284cd30baca5865fcd9f12b58bb740a24b220030df46d26"},
 ]
 
 [package.dependencies]
@@ -4411,4 +4412,4 @@ tests-strict = ["pytest (==4.6.0) ; python_version < \"3.10.0\" and python_versi
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "4e2826aca1d2c6c0ec9a68295c031d4973da319d635f74176af1fc01ec3f1d17"
+content-hash = "a95ddaf458a945da17914010b6f72d4b783e1b46dabee3e47dba2e80c679b23b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     'cloudpathlib[gs] >=0.17.0',
     'pyjwt >=2.8.0',
     'ssb-klass-python >=1.0.1',
-    'ssb-datadoc-model ==6.0.0',
+    'ssb-datadoc-model ==6.1.0',
     'typing-extensions >=4.12.2',
     'ruamel-yaml >=0.18.10',
     'google-auth >=2.38.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,19 +112,7 @@ disable_error_code = ["unreachable"]
 
 [[tool.mypy.overrides]]
 # Allow missing type hints in third-party libraries without type information.
-module = [
-    "nox",
-    "dapla",
-    "gcsfs",
-    "pyarrow",
-    "pyarrow.parquet",
-    "datadoc_model",
-    "datadoc_model.model",
-    "pytest_mock",
-    "testcontainers.*",
-    "httpx",
-    "ruamel.*",
-]
+module = ["nox", "dapla", "gcsfs", "pyarrow", "pyarrow.parquet", "pytest_mock", "testcontainers.*", "httpx", "ruamel.*"]
 ignore_missing_imports = true
 
 # Disable specific error codes in the 'tests' package

--- a/src/dapla_metadata/__init__.py
+++ b/src/dapla_metadata/__init__.py
@@ -7,7 +7,7 @@ warnings.filterwarnings(
     message="As the c extension couldn't be imported, `google-crc32c` is using a pure python implementation that is significantly slower.",
 )
 
-import datadoc_model.model as datadoc_model
+import datadoc_model.all_optional.model as datadoc_model
 
 from . import dapla
 from . import datasets

--- a/src/dapla_metadata/datasets/core.py
+++ b/src/dapla_metadata/datasets/core.py
@@ -217,7 +217,7 @@ class Datadoc:
             self._set_pseudonymization_metadata(existing_pseudonymization)
 
         set_default_values_variables(self.variables)
-        set_default_values_dataset(self.dataset)
+        set_default_values_dataset(cast("all_optional_model.Dataset", self.dataset))
         set_dataset_owner(self.dataset)
         self._create_variables_lookup()
         self._create_pseudo_variables_lookup()

--- a/src/dapla_metadata/datasets/core.py
+++ b/src/dapla_metadata/datasets/core.py
@@ -10,7 +10,8 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from datadoc_model import model
+import datadoc_model.all_optional.model as all_optional_model
+import datadoc_model.required.model as required_model
 from datadoc_model.model import DataSetStatus
 
 from dapla_metadata._shared import config
@@ -86,6 +87,7 @@ class Datadoc:
         statistic_subject_mapping: StatisticSubjectMapping | None = None,
         *,
         errors_as_warnings: bool = False,
+        validate_required_fields_on_existing_metadata: bool = False,
     ) -> None:
         """Initialize the Datadoc instance.
 
@@ -101,17 +103,23 @@ class Datadoc:
                 Defaults to None
             errors_as_warnings: Disable raising exceptions if inconsistencies
                 are found between existing and extracted metadata.
+            validate_required_fields_on_existing_metadata: Use a Pydantic model
+                which validates whether required fields are present when reading
+                in an existing metadata file.
         """
         self._statistic_subject_mapping = statistic_subject_mapping
         self.errors_as_warnings = errors_as_warnings
+        self.validate_required_fields_on_existing_metadata = (
+            validate_required_fields_on_existing_metadata
+        )
         self.metadata_document: pathlib.Path | CloudPath | None = None
-        self.container: model.MetadataContainer | None = None
+        self.container: all_optional_model.MetadataContainer | None = None
         self.dataset_path: pathlib.Path | CloudPath | None = None
-        self.dataset = model.Dataset()
+        self.dataset = all_optional_model.Dataset()
         self.variables: list = []
-        self.pseudo_variables: list[model.PseudoVariable] = []
-        self.variables_lookup: dict[str, model.Variable] = {}
-        self.pseudo_variables_lookup: dict[str, model.PseudoVariable] = {}
+        self.pseudo_variables: list[all_optional_model.PseudoVariable] = []
+        self.variables_lookup: dict[str, all_optional_model.Variable] = {}
+        self.pseudo_variables_lookup: dict[str, all_optional_model.PseudoVariable] = {}
         self.explicitly_defined_metadata_document = False
         self.dataset_consistency_status: list = []
         if metadata_document_path:
@@ -149,9 +157,11 @@ class Datadoc:
         - The 'contains_personal_data' attribute is set to False if not specified.
         - A lookup dictionary for variables is created based on their short names.
         """
-        extracted_metadata: model.DatadocMetadata | None = None
-        existing_metadata: model.DatadocMetadata | None = None
-        existing_pseudonymization: model.PseudonymizationMetadata | None = None
+        extracted_metadata: all_optional_model.DatadocMetadata | None = None
+        existing_metadata: all_optional_model.DatadocMetadata | None = None
+        existing_pseudonymization: (
+            all_optional_model.PseudonymizationMetadata | None
+        ) = None
 
         if self.metadata_document and self.metadata_document.exists():
             existing_metadata = self._extract_metadata_from_existing_document(
@@ -166,7 +176,7 @@ class Datadoc:
 
         if (
             self.dataset_path is not None
-            and self.dataset == model.Dataset()
+            and self.dataset == all_optional_model.Dataset()
             and len(self.variables) == 0
         ):
             extracted_metadata = self._extract_metadata_from_dataset(self.dataset_path)
@@ -214,7 +224,7 @@ class Datadoc:
 
     def _get_existing_file_path(
         self,
-        extracted_metadata: model.DatadocMetadata | None,
+        extracted_metadata: all_optional_model.DatadocMetadata | None,
     ) -> str:
         if (
             extracted_metadata is not None
@@ -227,7 +237,7 @@ class Datadoc:
 
     def _set_metadata(
         self,
-        merged_metadata: model.DatadocMetadata | None,
+        merged_metadata: all_optional_model.DatadocMetadata | None,
     ) -> None:
         if not merged_metadata or not (
             merged_metadata.dataset and merged_metadata.variables
@@ -239,7 +249,7 @@ class Datadoc:
 
     def _set_pseudonymization_metadata(
         self,
-        existing_pseudonymization: model.PseudonymizationMetadata | None,
+        existing_pseudonymization: all_optional_model.PseudonymizationMetadata | None,
     ) -> None:
         if not existing_pseudonymization or not (
             existing_pseudonymization.pseudo_variables is not None
@@ -264,8 +274,8 @@ class Datadoc:
     def _check_dataset_consistency(
         new_dataset_path: Path | CloudPath,
         existing_dataset_path: Path,
-        extracted_metadata: model.DatadocMetadata,
-        existing_metadata: model.DatadocMetadata,
+        extracted_metadata: all_optional_model.DatadocMetadata,
+        existing_metadata: all_optional_model.DatadocMetadata,
     ) -> list[dict[str, object]]:
         """Run consistency tests.
 
@@ -353,20 +363,20 @@ class Datadoc:
 
     @staticmethod
     def _merge_metadata(
-        extracted_metadata: model.DatadocMetadata | None,
-        existing_metadata: model.DatadocMetadata | None,
-    ) -> model.DatadocMetadata:
+        extracted_metadata: all_optional_model.DatadocMetadata | None,
+        existing_metadata: all_optional_model.DatadocMetadata | None,
+    ) -> all_optional_model.DatadocMetadata:
         if not existing_metadata:
             logger.warning(
                 "No existing metadata found, no merge to perform. Continuing with extracted metadata.",
             )
-            return extracted_metadata or model.DatadocMetadata()
+            return extracted_metadata or all_optional_model.DatadocMetadata()
 
         if not extracted_metadata:
             return existing_metadata
 
         # Use the extracted metadata as a base
-        merged_metadata = model.DatadocMetadata(
+        merged_metadata = all_optional_model.DatadocMetadata(
             dataset=copy.deepcopy(extracted_metadata.dataset),
             variables=[],
         )
@@ -387,7 +397,7 @@ class Datadoc:
     def _extract_metadata_from_existing_document(
         self,
         document: pathlib.Path | CloudPath,
-    ) -> model.DatadocMetadata | None:
+    ) -> all_optional_model.DatadocMetadata | None:
         """Read metadata from an existing metadata document.
 
         If an existing metadata document is available, this method reads and
@@ -403,6 +413,11 @@ class Datadoc:
         Raises:
             json.JSONDecodeError: If the metadata document cannot be parsed.
         """
+        metadata_model = (
+            required_model
+            if self.validate_required_fields_on_existing_metadata
+            else all_optional_model
+        )
         fresh_metadata = {}
         try:
             with document.open(mode="r", encoding="utf-8") as file:
@@ -412,7 +427,7 @@ class Datadoc:
                 fresh_metadata,
             )
             if is_metadata_in_container_structure(fresh_metadata):
-                self.container = model.MetadataContainer.model_validate_json(
+                self.container = metadata_model.MetadataContainer.model_validate_json(
                     json.dumps(fresh_metadata),
                 )
                 datadoc_metadata = fresh_metadata["datadoc"]
@@ -420,7 +435,7 @@ class Datadoc:
                 datadoc_metadata = fresh_metadata
             if datadoc_metadata is None:
                 return None
-            return model.DatadocMetadata.model_validate_json(
+            return metadata_model.DatadocMetadata.model_validate_json(
                 json.dumps(datadoc_metadata),
             )
         except json.JSONDecodeError:
@@ -435,7 +450,7 @@ class Datadoc:
     def _extract_pseudonymization_from_existing_document(
         self,
         document: pathlib.Path | CloudPath,
-    ) -> model.PseudonymizationMetadata | None:
+    ) -> all_optional_model.PseudonymizationMetadata | None:
         """Read pseudo metadata from an existing metadata document.
 
         If there is pseudo metadata in the document supplied, the method validates and returns the pseudonymization structure.
@@ -446,6 +461,12 @@ class Datadoc:
         Raises:
             json.JSONDecodeError: If the metadata document cannot be parsed.
         """
+        metadata_model = (
+            required_model
+            if self.validate_required_fields_on_existing_metadata
+            else all_optional_model
+        )
+
         try:
             with document.open(mode="r", encoding="utf-8") as file:
                 fresh_metadata = json.load(file)
@@ -464,7 +485,7 @@ class Datadoc:
         if pseudonymization_metadata is None:
             return None
 
-        return model.PseudonymizationMetadata.model_validate_json(
+        return metadata_model.PseudonymizationMetadata.model_validate_json(
             json.dumps(pseudonymization_metadata),
         )
 
@@ -500,7 +521,7 @@ class Datadoc:
     def _extract_metadata_from_dataset(
         self,
         dataset: pathlib.Path | CloudPath,
-    ) -> model.DatadocMetadata:
+    ) -> all_optional_model.DatadocMetadata:
         """Obtain what metadata we can from the dataset itself.
 
         This makes it easier for the user by 'pre-filling' certain fields.
@@ -520,9 +541,9 @@ class Datadoc:
                 - variables: A list of fields extracted from the dataset schema.
         """
         dapla_dataset_path_info = DaplaDatasetPathInfo(dataset)
-        metadata = model.DatadocMetadata()
+        metadata = all_optional_model.DatadocMetadata()
 
-        metadata.dataset = model.Dataset(
+        metadata.dataset = all_optional_model.Dataset(
             short_name=dapla_dataset_path_info.dataset_short_name,
             dataset_state=dapla_dataset_path_info.dataset_state,
             dataset_status=DataSetStatus.DRAFT,
@@ -586,12 +607,14 @@ class Datadoc:
         if self.container:
             self.container.datadoc = datadoc
             if not self.container.pseudonymization:
-                self.container.pseudonymization = model.PseudonymizationMetadata(
-                    pseudo_dataset=model.PseudoDataset()
+                self.container.pseudonymization = (
+                    all_optional_model.PseudonymizationMetadata(
+                        pseudo_dataset=all_optional_model.PseudoDataset()
+                    )
                 )
             self.container.pseudonymization.pseudo_variables = self.pseudo_variables
         else:
-            self.container = model.MetadataContainer(datadoc=datadoc)
+            self.container = all_optional_model.MetadataContainer(datadoc=datadoc)
         if self.metadata_document:
             content = self.container.model_dump_json(indent=4)
             self.metadata_document.write_text(content)
@@ -623,12 +646,14 @@ class Datadoc:
     def add_pseudo_variable(self, variable_short_name: str) -> None:
         """Adds a new pseudo variable to the list of pseudonymized variables."""
         if self.variables_lookup[variable_short_name] is not None:
-            pseudo_variable = model.PseudoVariable(short_name=variable_short_name)
+            pseudo_variable = all_optional_model.PseudoVariable(
+                short_name=variable_short_name
+            )
             self.pseudo_variables.append(pseudo_variable)
             self.pseudo_variables_lookup[variable_short_name] = pseudo_variable
 
     def get_pseudo_variable(
         self, variable_short_name: str
-    ) -> model.PseudoVariable | None:
+    ) -> all_optional_model.PseudoVariable | None:
         """Finds a pseudo variable by shortname."""
         return self.pseudo_variables_lookup.get(variable_short_name)

--- a/src/dapla_metadata/datasets/core.py
+++ b/src/dapla_metadata/datasets/core.py
@@ -13,7 +13,7 @@ from typing import cast
 
 import datadoc_model.all_optional.model as all_optional_model
 import datadoc_model.required.model as required_model
-from datadoc_model.model import DataSetStatus
+from datadoc_model.all_optional.model import DataSetStatus
 
 from dapla_metadata._shared import config
 from dapla_metadata.dapla import user_info
@@ -32,8 +32,8 @@ from dapla_metadata.datasets.utility.constants import INCONSISTENCIES_MESSAGE
 from dapla_metadata.datasets.utility.constants import METADATA_DOCUMENT_FILE_SUFFIX
 from dapla_metadata.datasets.utility.constants import NUM_OBLIGATORY_DATASET_FIELDS
 from dapla_metadata.datasets.utility.constants import NUM_OBLIGATORY_VARIABLES_FIELDS
-from dapla_metadata.datasets.utility.utils import ExistingMetadataType
 from dapla_metadata.datasets.utility.utils import ExistingPseudonymizationMetadataType
+from dapla_metadata.datasets.utility.utils import OptionalDatadocMetadataType
 from dapla_metadata.datasets.utility.utils import calculate_percentage
 from dapla_metadata.datasets.utility.utils import derive_assessment_from_state
 from dapla_metadata.datasets.utility.utils import get_timestamp_now
@@ -160,7 +160,7 @@ class Datadoc:
         - A lookup dictionary for variables is created based on their short names.
         """
         extracted_metadata: all_optional_model.DatadocMetadata | None = None
-        existing_metadata: ExistingMetadataType = None
+        existing_metadata: OptionalDatadocMetadataType = None
         existing_pseudonymization: ExistingPseudonymizationMetadataType = None
 
         if self.metadata_document and self.metadata_document.exists():
@@ -237,7 +237,7 @@ class Datadoc:
 
     def _set_metadata(
         self,
-        merged_metadata: ExistingMetadataType,
+        merged_metadata: OptionalDatadocMetadataType,
     ) -> None:
         if not merged_metadata or not (
             merged_metadata.dataset and merged_metadata.variables
@@ -278,7 +278,7 @@ class Datadoc:
         new_dataset_path: Path | CloudPath,
         existing_dataset_path: Path,
         extracted_metadata: all_optional_model.DatadocMetadata,
-        existing_metadata: ExistingMetadataType,
+        existing_metadata: OptionalDatadocMetadataType,
     ) -> list[dict[str, object]]:
         """Run consistency tests.
 
@@ -369,7 +369,7 @@ class Datadoc:
     @staticmethod
     def _merge_metadata(
         extracted_metadata: all_optional_model.DatadocMetadata | None,
-        existing_metadata: ExistingMetadataType,
+        existing_metadata: OptionalDatadocMetadataType,
     ) -> all_optional_model.DatadocMetadata:
         if not existing_metadata:
             logger.warning(
@@ -404,7 +404,7 @@ class Datadoc:
     def _extract_metadata_from_existing_document(
         self,
         document: pathlib.Path | CloudPath,
-    ) -> ExistingMetadataType:
+    ) -> OptionalDatadocMetadataType:
         """Read metadata from an existing metadata document.
 
         If an existing metadata document is available, this method reads and

--- a/src/dapla_metadata/datasets/core.py
+++ b/src/dapla_metadata/datasets/core.py
@@ -85,7 +85,6 @@ class Datadoc:
         dataset_path: str | None = None,
         metadata_document_path: str | None = None,
         statistic_subject_mapping: StatisticSubjectMapping | None = None,
-        *,
         errors_as_warnings: bool = False,
         validate_required_fields_on_existing_metadata: bool = False,
     ) -> None:

--- a/src/dapla_metadata/datasets/core.py
+++ b/src/dapla_metadata/datasets/core.py
@@ -257,7 +257,10 @@ class Datadoc:
             msg = "Error reading pseudonymization metadata"
             logger.error(msg)
             return
-        self.pseudo_variables = existing_pseudonymization.pseudo_variables
+        self.pseudo_variables = cast(
+            "list[all_optional_model.PseudoVariable]",
+            existing_pseudonymization.pseudo_variables,
+        )
 
     def _create_variables_lookup(self) -> None:
         self.variables_lookup = {

--- a/src/dapla_metadata/datasets/dapla_dataset_path_info.py
+++ b/src/dapla_metadata/datasets/dapla_dataset_path_info.py
@@ -14,7 +14,7 @@ from typing import Literal
 
 import arrow
 from cloudpathlib import GSPath
-from datadoc_model.model import DataSetState
+from datadoc_model.all_optional.model import DataSetState
 
 if TYPE_CHECKING:
     import datetime

--- a/src/dapla_metadata/datasets/dataset_parser.py
+++ b/src/dapla_metadata/datasets/dataset_parser.py
@@ -12,10 +12,10 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 import pandas as pd
-from datadoc_model.model import DataType
-from datadoc_model.model import LanguageStringType
-from datadoc_model.model import LanguageStringTypeItem
-from datadoc_model.model import Variable
+from datadoc_model.all_optional.model import DataType
+from datadoc_model.all_optional.model import LanguageStringType
+from datadoc_model.all_optional.model import LanguageStringTypeItem
+from datadoc_model.all_optional.model import Variable
 from pyarrow import parquet as pq
 
 from dapla_metadata.datasets.utility.enums import SupportedLanguages

--- a/src/dapla_metadata/datasets/utility/constants.py
+++ b/src/dapla_metadata/datasets/utility/constants.py
@@ -1,7 +1,7 @@
 """Repository for constant values in Datadoc backend."""
 
-from datadoc_model.model import LanguageStringType
-from datadoc_model.model import LanguageStringTypeItem
+from datadoc_model.all_optional.model import LanguageStringType
+from datadoc_model.all_optional.model import LanguageStringTypeItem
 
 VALIDATION_ERROR = "Validation error: "
 

--- a/src/dapla_metadata/datasets/utility/utils.py
+++ b/src/dapla_metadata/datasets/utility/utils.py
@@ -133,7 +133,9 @@ def set_default_values_variables(variables: list) -> None:
             v.variable_role = VariableRole.MEASURE
 
 
-def set_default_values_dataset(dataset: model.Dataset) -> None:
+def set_default_values_dataset(
+    dataset: all_optional_model.Dataset | required_model.Dataset,
+) -> None:
     """Set default values on dataset.
 
     Args:

--- a/src/dapla_metadata/datasets/utility/utils.py
+++ b/src/dapla_metadata/datasets/utility/utils.py
@@ -4,7 +4,11 @@ import datetime  # import is needed in xdoctest
 import logging
 import pathlib
 import uuid
+from typing import cast
 
+import datadoc_model
+import datadoc_model.all_optional.model as all_optional_model
+import datadoc_model.required.model as required_model
 import google.auth
 from cloudpathlib import CloudPath
 from cloudpathlib import GSClient
@@ -33,6 +37,16 @@ from dapla_metadata.datasets.utility.constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+ExistingMetadataType = (
+    all_optional_model.DatadocMetadata | required_model.DatadocMetadata | None
+)
+ExistingPseudonymizationMetadataType = (
+    all_optional_model.PseudonymizationMetadata
+    | required_model.PseudonymizationMetadata
+    | None
+)
 
 
 def get_timestamp_now() -> datetime.datetime:
@@ -449,7 +463,7 @@ def override_dataset_fields(
 
 
 def merge_variables(
-    existing_metadata: model.DatadocMetadata,
+    existing_metadata: ExistingMetadataType,
     extracted_metadata: model.DatadocMetadata,
     merged_metadata: model.DatadocMetadata,
 ) -> model.DatadocMetadata:
@@ -470,7 +484,8 @@ def merge_variables(
         and `extracted_metadata`.
     """
     if (
-        existing_metadata.variables is not None
+        existing_metadata is not None
+        and existing_metadata.variables is not None
         and extracted_metadata is not None
         and extracted_metadata.variables is not None
         and merged_metadata.variables is not None
@@ -494,7 +509,9 @@ def merge_variables(
                 existing.contains_data_until = (
                     extracted.contains_data_until or existing.contains_data_until
                 )
-                merged_metadata.variables.append(existing)
+                merged_metadata.variables.append(
+                    cast("datadoc_model.all_optional.model.Variable", existing)
+                )
             else:
                 # If there is no existing metadata for this variable, we just use what we have extracted
                 merged_metadata.variables.append(extracted)

--- a/src/dapla_metadata/datasets/utility/utils.py
+++ b/src/dapla_metadata/datasets/utility/utils.py
@@ -156,7 +156,9 @@ def set_default_values_dataset(
         dataset.contains_personal_data = False
 
 
-def set_dataset_owner(dataset: model.Dataset) -> None:
+def set_dataset_owner(
+    dataset: all_optional_model.Dataset | required_model.Dataset,
+) -> None:
     """Sets the owner of the dataset from the DAPLA_GROUP_CONTEXT enviornment variable.
 
     Args:
@@ -169,7 +171,7 @@ def set_dataset_owner(dataset: model.Dataset) -> None:
 
 
 def set_variables_inherit_from_dataset(
-    dataset: model.Dataset,
+    dataset: all_optional_model.Dataset | required_model.Dataset,
     variables: list,
 ) -> None:
     """Set specific dataset values on a list of variable objects.
@@ -299,7 +301,9 @@ def _is_missing_metadata(
     )
 
 
-def num_obligatory_dataset_fields_completed(dataset: model.Dataset) -> int:
+def num_obligatory_dataset_fields_completed(
+    dataset: all_optional_model.Dataset | required_model.Dataset,
+) -> int:
     """Count the number of completed obligatory dataset fields.
 
     This function returns the total count of obligatory fields in the dataset that
@@ -361,7 +365,9 @@ def num_obligatory_variable_fields_completed(variable: model.Variable) -> int:
     return NUM_OBLIGATORY_VARIABLES_FIELDS - len(missing_metadata)
 
 
-def get_missing_obligatory_dataset_fields(dataset: model.Dataset) -> list:
+def get_missing_obligatory_dataset_fields(
+    dataset: all_optional_model.Dataset | required_model.Dataset,
+) -> list:
     """Identify all obligatory dataset fields that are missing values.
 
     This function checks for obligatory fields that are either directly missing
@@ -439,7 +445,7 @@ def running_in_notebook() -> bool:
 
 def override_dataset_fields(
     merged_metadata: model.DatadocMetadata,
-    existing_metadata: model.DatadocMetadata,
+    existing_metadata: ExistingMetadataType,
 ) -> None:
     """Overrides specific fields in the dataset of `merged_metadata` with values from the dataset of `existing_metadata`.
 

--- a/src/dapla_metadata/datasets/utility/utils.py
+++ b/src/dapla_metadata/datasets/utility/utils.py
@@ -14,9 +14,9 @@ from cloudpathlib import CloudPath
 from cloudpathlib import GSClient
 from cloudpathlib import GSPath
 from datadoc_model import model
-from datadoc_model.model import Assessment
-from datadoc_model.model import DataSetState
-from datadoc_model.model import VariableRole
+from datadoc_model.all_optional.model import Assessment
+from datadoc_model.all_optional.model import DataSetState
+from datadoc_model.all_optional.model import VariableRole
 
 from dapla_metadata.dapla import user_info
 from dapla_metadata.datasets.utility.constants import (
@@ -38,10 +38,11 @@ from dapla_metadata.datasets.utility.constants import (
 
 logger = logging.getLogger(__name__)
 
-
-ExistingMetadataType = (
-    all_optional_model.DatadocMetadata | required_model.DatadocMetadata | None
+DatadocMetadataType = (
+    all_optional_model.DatadocMetadata | required_model.DatadocMetadata
 )
+DatasetType = all_optional_model.Dataset | required_model.Dataset
+OptionalDatadocMetadataType = DatadocMetadataType | None
 ExistingPseudonymizationMetadataType = (
     all_optional_model.PseudonymizationMetadata
     | required_model.PseudonymizationMetadata
@@ -134,7 +135,7 @@ def set_default_values_variables(variables: list) -> None:
 
 
 def set_default_values_dataset(
-    dataset: all_optional_model.Dataset | required_model.Dataset,
+    dataset: DatasetType,
 ) -> None:
     """Set default values on dataset.
 
@@ -157,7 +158,7 @@ def set_default_values_dataset(
 
 
 def set_dataset_owner(
-    dataset: all_optional_model.Dataset | required_model.Dataset,
+    dataset: DatasetType,
 ) -> None:
     """Sets the owner of the dataset from the DAPLA_GROUP_CONTEXT enviornment variable.
 
@@ -171,7 +172,7 @@ def set_dataset_owner(
 
 
 def set_variables_inherit_from_dataset(
-    dataset: all_optional_model.Dataset | required_model.Dataset,
+    dataset: DatasetType,
     variables: list,
 ) -> None:
     """Set specific dataset values on a list of variable objects.
@@ -302,7 +303,7 @@ def _is_missing_metadata(
 
 
 def num_obligatory_dataset_fields_completed(
-    dataset: all_optional_model.Dataset | required_model.Dataset,
+    dataset: DatasetType,
 ) -> int:
     """Count the number of completed obligatory dataset fields.
 
@@ -366,7 +367,7 @@ def num_obligatory_variable_fields_completed(variable: model.Variable) -> int:
 
 
 def get_missing_obligatory_dataset_fields(
-    dataset: all_optional_model.Dataset | required_model.Dataset,
+    dataset: DatasetType,
 ) -> list:
     """Identify all obligatory dataset fields that are missing values.
 
@@ -444,8 +445,9 @@ def running_in_notebook() -> bool:
 
 
 def override_dataset_fields(
-    merged_metadata: model.DatadocMetadata,
-    existing_metadata: ExistingMetadataType,
+    merged_metadata: all_optional_model.DatadocMetadata,
+    existing_metadata: all_optional_model.DatadocMetadata
+    | required_model.DatadocMetadata,
 ) -> None:
     """Overrides specific fields in the dataset of `merged_metadata` with values from the dataset of `existing_metadata`.
 
@@ -471,10 +473,10 @@ def override_dataset_fields(
 
 
 def merge_variables(
-    existing_metadata: ExistingMetadataType,
-    extracted_metadata: model.DatadocMetadata,
-    merged_metadata: model.DatadocMetadata,
-) -> model.DatadocMetadata:
+    existing_metadata: OptionalDatadocMetadataType,
+    extracted_metadata: all_optional_model.DatadocMetadata,
+    merged_metadata: all_optional_model.DatadocMetadata,
+) -> all_optional_model.DatadocMetadata:
     """Merges variables from the extracted metadata into the existing metadata and updates the merged metadata.
 
     This function compares the variables from `extracted_metadata` with those in `existing_metadata`.
@@ -488,7 +490,7 @@ def merge_variables(
         merged_metadata: The metadata object that will contain the result of the merge.
 
     Returns:
-        model.DatadocMetadata: The `merged_metadata` object containing variables from both `existing_metadata`
+        all_optional_model.DatadocMetadata: The `merged_metadata` object containing variables from both `existing_metadata`
         and `extracted_metadata`.
     """
     if (

--- a/tests/datasets/constants.py
+++ b/tests/datasets/constants.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from datadoc_model.model import DataType
+from datadoc_model.all_optional.model import DataType
 
 TEST_BUCKET_PARQUET_FILEPATH = "gs://ssb-staging-dapla-felles-data-delt/datadoc/klargjorte_data/person_data_v1.parquet"
 

--- a/tests/datasets/resources/existing_metadata_file/person_testdata_p2020-12-31_p2020-12-31_v1__DOC.json
+++ b/tests/datasets/resources/existing_metadata_file/person_testdata_p2020-12-31_p2020-12-31_v1__DOC.json
@@ -1,7 +1,7 @@
 {
   "document_version": "0.0.1",
   "datadoc": {
-    "percentage_complete": 100,
+    "percentage_complete": 98,
     "document_version": "4.0.0",
     "dataset": {
       "short_name": "person_testdata",
@@ -92,9 +92,9 @@
       "owner": "320",
       "file_path": "tests/resources/datasets/person_testdata_p2021-12-31_p2021-12-31_v1.parquet",
       "metadata_created_date": "2024-07-09T09:47:28.347248Z",
-      "metadata_created_by": null,
-      "metadata_last_updated_date": "2024-08-01T07:18:56.706420Z",
-      "metadata_last_updated_by": null,
+      "metadata_created_by": "kari.nordmann@ssb.no",
+      "metadata_last_updated_date": "2025-05-06T09:12:45.651034Z",
+      "metadata_last_updated_by": "kari.nordmann@ssb.no",
       "contains_data_from": "2021-12-31",
       "contains_data_until": "2021-12-31"
     },

--- a/tests/datasets/test_dapla_dataset_path_info.py
+++ b/tests/datasets/test_dapla_dataset_path_info.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
-from datadoc_model.model import DataSetState
+from datadoc_model.all_optional.model import DataSetState
 
 from dapla_metadata.datasets.dapla_dataset_path_info import ISO_YEAR
 from dapla_metadata.datasets.dapla_dataset_path_info import ISO_YEAR_MONTH

--- a/tests/datasets/test_datadoc_metadata.py
+++ b/tests/datasets/test_datadoc_metadata.py
@@ -24,6 +24,7 @@ from datadoc_model.model import DataType
 from datadoc_model.model import IsPersonalData
 from datadoc_model.model import Variable
 from datadoc_model.model import VariableRole
+from pydantic import ValidationError
 
 from dapla_metadata.dapla.user_info import TestUserInfo
 from dapla_metadata.datasets.core import Datadoc
@@ -38,8 +39,8 @@ from tests.datasets.constants import TEST_BUCKET_NAMING_STANDARD_COMPATIBLE_PATH
 from tests.datasets.constants import TEST_DATASETS_DIRECTORY
 from tests.datasets.constants import TEST_EXISTING_METADATA_DIRECTORY
 from tests.datasets.constants import TEST_EXISTING_METADATA_FILE_NAME
-from tests.datasets.constants import TEST_EXISTING_METADATA_FILEPATH
 from tests.datasets.constants import TEST_EXISTING_METADATA_NAMING_STANDARD_FILEPATH
+from tests.datasets.constants import TEST_EXISTING_METADATA_WITH_VALID_ID_DIRECTORY
 from tests.datasets.constants import TEST_NAMING_STANDARD_COMPATIBLE_DATASET
 from tests.datasets.constants import TEST_PARQUET_FILEPATH
 from tests.datasets.constants import TEST_PROCESSED_DATA_POPULATION_DIRECTORY
@@ -209,17 +210,33 @@ def test_existing_metadata_valid_id(
 
 @pytest.mark.parametrize(
     "metadata_document",
-    [TEST_EXISTING_METADATA_FILEPATH],
+    [TEST_EXISTING_METADATA_WITH_VALID_ID_DIRECTORY / TEST_EXISTING_METADATA_FILE_NAME],
 )
 @pytest.mark.usefixtures("_mock_timestamp", "_mock_user_info")
-def test_validate_required_fields(
+def test_validate_required_fields_incomplete_metadata(
+    metadata_document: Path,
+    subject_mapping_fake_statistical_structure: StatisticSubjectMapping,
+):
+    with pytest.raises(ValidationError):
+        Datadoc(
+            metadata_document_path=str(metadata_document),
+            statistic_subject_mapping=subject_mapping_fake_statistical_structure,
+            validate_required_fields_on_existing_metadata=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "metadata_document",
+    [TEST_EXISTING_METADATA_NAMING_STANDARD_FILEPATH],
+)
+@pytest.mark.usefixtures("_mock_timestamp", "_mock_user_info")
+def test_validate_required_fields_complete_metadata(
     metadata_document: Path,
     subject_mapping_fake_statistical_structure: StatisticSubjectMapping,
 ):
     Datadoc(
         metadata_document_path=str(metadata_document),
         statistic_subject_mapping=subject_mapping_fake_statistical_structure,
-        errors_as_warnings=False,
         validate_required_fields_on_existing_metadata=True,
     )
 

--- a/tests/datasets/test_datadoc_metadata.py
+++ b/tests/datasets/test_datadoc_metadata.py
@@ -38,6 +38,7 @@ from tests.datasets.constants import TEST_BUCKET_NAMING_STANDARD_COMPATIBLE_PATH
 from tests.datasets.constants import TEST_DATASETS_DIRECTORY
 from tests.datasets.constants import TEST_EXISTING_METADATA_DIRECTORY
 from tests.datasets.constants import TEST_EXISTING_METADATA_FILE_NAME
+from tests.datasets.constants import TEST_EXISTING_METADATA_FILEPATH
 from tests.datasets.constants import TEST_EXISTING_METADATA_NAMING_STANDARD_FILEPATH
 from tests.datasets.constants import TEST_NAMING_STANDARD_COMPATIBLE_DATASET
 from tests.datasets.constants import TEST_PARQUET_FILEPATH
@@ -204,6 +205,23 @@ def test_existing_metadata_valid_id(
     with existing_metadata_file.open() as f:
         post_write_id = json.load(f)["datadoc"]["dataset"]["id"]
     assert post_write_id == pre_open_id
+
+
+@pytest.mark.parametrize(
+    "metadata_document",
+    [TEST_EXISTING_METADATA_FILEPATH],
+)
+@pytest.mark.usefixtures("_mock_timestamp", "_mock_user_info")
+def test_validate_required_fields(
+    metadata_document: Path,
+    subject_mapping_fake_statistical_structure: StatisticSubjectMapping,
+):
+    Datadoc(
+        metadata_document_path=str(metadata_document),
+        statistic_subject_mapping=subject_mapping_fake_statistical_structure,
+        errors_as_warnings=False,
+        validate_required_fields_on_existing_metadata=True,
+    )
 
 
 def test_dataset_short_name(metadata: Datadoc):

--- a/tests/datasets/test_datadoc_metadata.py
+++ b/tests/datasets/test_datadoc_metadata.py
@@ -15,15 +15,15 @@ from uuid import UUID
 
 import arrow
 import pytest
-from datadoc_model.model import Assessment
-from datadoc_model.model import DatadocMetadata
-from datadoc_model.model import Dataset
-from datadoc_model.model import DataSetState
-from datadoc_model.model import DataSetStatus
-from datadoc_model.model import DataType
-from datadoc_model.model import IsPersonalData
-from datadoc_model.model import Variable
-from datadoc_model.model import VariableRole
+from datadoc_model.all_optional.model import Assessment
+from datadoc_model.all_optional.model import DatadocMetadata
+from datadoc_model.all_optional.model import Dataset
+from datadoc_model.all_optional.model import DataSetState
+from datadoc_model.all_optional.model import DataSetStatus
+from datadoc_model.all_optional.model import DataType
+from datadoc_model.all_optional.model import IsPersonalData
+from datadoc_model.all_optional.model import Variable
+from datadoc_model.all_optional.model import VariableRole
 from pydantic import ValidationError
 
 from dapla_metadata.dapla.user_info import TestUserInfo

--- a/tests/datasets/test_dataset_parser.py
+++ b/tests/datasets/test_dataset_parser.py
@@ -5,10 +5,10 @@ import pathlib
 
 import pandas as pd
 import pytest
-from datadoc_model.model import DataType
-from datadoc_model.model import LanguageStringType
-from datadoc_model.model import LanguageStringTypeItem
-from datadoc_model.model import Variable
+from datadoc_model.all_optional.model import DataType
+from datadoc_model.all_optional.model import LanguageStringType
+from datadoc_model.all_optional.model import LanguageStringTypeItem
+from datadoc_model.all_optional.model import Variable
 
 from dapla_metadata.datasets.dataset_parser import KNOWN_BOOLEAN_TYPES
 from dapla_metadata.datasets.dataset_parser import KNOWN_DATETIME_TYPES

--- a/tests/datasets/test_validators.py
+++ b/tests/datasets/test_validators.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import datadoc_model
 import pytest
 from datadoc_model import model
-from datadoc_model.model import TemporalityTypeType
+from datadoc_model.all_optional.model import TemporalityTypeType
 from pydantic import ValidationError
 
 from dapla_metadata.datasets.model_validation import ObligatoryDatasetWarning
@@ -101,8 +101,10 @@ def test_variables_inherit_dates(
 
 def test_variables_inherit_temporality_type_value(metadata: Datadoc):
     assert all(v.temporality_type is None for v in metadata.variables)
-    metadata.dataset.temporality_type = datadoc_model.model.TemporalityTypeType(
-        TemporalityTypeType.FIXED.value,
+    metadata.dataset.temporality_type = (
+        datadoc_model.all_optional.model.TemporalityTypeType(
+            TemporalityTypeType.FIXED.value,
+        )
     )
     metadata.write_metadata_document()
     assert all(


### PR DESCRIPTION
This will allow validating that completed datadoc metadata documents contain all of the required metadata.

- Implemented as a flag on Datadoc class
- Update to ssb-datadoc-model v6.1.0
- Explicitly name models `all_optional_model` and `required_model`
