### PR TITLE
Only consider primary placement when mapping from a specific statistic to a subject field

### DIFF
--- a/src/dapla_metadata/datasets/statistic_subject_mapping.py
+++ b/src/dapla_metadata/datasets/statistic_subject_mapping.py
@@ -97,7 +97,7 @@ class StatisticSubjectMapping(GetExternalSource):
         """
         for p in self.primary_subjects:
             for s in p.secondary_subjects:
-                if statistic_short_name in s.statistic_short_names_primary and s.statistic_short_names_primary[statistic_short_name] :
+                if s.statistic_short_names_primary.get(statistic_short_name):
                     logger.debug("Got %s from %s", s, statistic_short_name)
                     return s.subject_code
 

--- a/src/dapla_metadata/datasets/statistic_subject_mapping.py
+++ b/src/dapla_metadata/datasets/statistic_subject_mapping.py
@@ -106,14 +106,12 @@ class StatisticSubjectMapping(GetExternalSource):
                         primary.append(s)
                     else:
                         non_primary.append(s)
-        
+
         priority: list[SecondarySubject] = primary + non_primary
         if priority:
             result: SecondarySubject = priority[0]
             logger.debug("Got %s from %s", result, statistic_short_name)
             return result.subject_code
-
-        
 
         logger.debug("No secondary subject found for %s", statistic_short_name)
         return None
@@ -155,9 +153,11 @@ class StatisticSubjectMapping(GetExternalSource):
                     self._extract_titles(s.titler),
                     s["emnekode"],
                     [statistikk["kortnavn"] for statistikk in s.find_all("Statistikk")],
-                    {statistikk["kortnavn"]: statistikk["isPrimaerPlassering"] == "true" for statistikk in s.find_all("Statistikk")}
-
-
+                    {
+                        statistikk["kortnavn"]: statistikk["isPrimaerPlassering"]
+                        == "true"
+                        for statistikk in s.find_all("Statistikk")
+                    },
                 )
                 for s in p.find_all("delemne")
             ]

--- a/src/dapla_metadata/datasets/statistic_subject_mapping.py
+++ b/src/dapla_metadata/datasets/statistic_subject_mapping.py
@@ -56,8 +56,7 @@ class Subject:
 class SecondarySubject(Subject):
     """Data structure for secondary subjects or 'delemne'."""
 
-    statistic_short_names: list[str]
-    primary_placement: dict[str, bool]
+    statistic_short_names_primary: dict[str, bool]
 
 
 @dataclass
@@ -96,22 +95,11 @@ class StatisticSubjectMapping(GetExternalSource):
 
         Returns the secondary subject string if found, else None.
         """
-        primary: list[SecondarySubject] = []
-        non_primary: list[SecondarySubject] = []
-
         for p in self.primary_subjects:
             for s in p.secondary_subjects:
-                if statistic_short_name in s.statistic_short_names:
-                    if s.primary_placement[statistic_short_name]:
-                        primary.append(s)
-                    else:
-                        non_primary.append(s)
-
-        priority: list[SecondarySubject] = primary + non_primary
-        if priority:
-            result: SecondarySubject = priority[0]
-            logger.debug("Got %s from %s", result, statistic_short_name)
-            return result.subject_code
+                if statistic_short_name in s.statistic_short_names_primary and s.statistic_short_names_primary[statistic_short_name] :
+                    logger.debug("Got %s from %s", s, statistic_short_name)
+                    return s.subject_code
 
         logger.debug("No secondary subject found for %s", statistic_short_name)
         return None
@@ -152,7 +140,6 @@ class StatisticSubjectMapping(GetExternalSource):
                 SecondarySubject(
                     self._extract_titles(s.titler),
                     s["emnekode"],
-                    [statistikk["kortnavn"] for statistikk in s.find_all("Statistikk")],
                     {
                         statistikk["kortnavn"]: statistikk["isPrimaerPlassering"]
                         == "true"

--- a/src/dapla_metadata/datasets/statistic_subject_mapping.py
+++ b/src/dapla_metadata/datasets/statistic_subject_mapping.py
@@ -56,7 +56,7 @@ class Subject:
 class SecondarySubject(Subject):
     """Data structure for secondary subjects or 'delemne'."""
 
-    statistic_short_names_primary: dict[str, bool]
+    statistic_short_names: list[str]
 
 
 @dataclass
@@ -97,7 +97,7 @@ class StatisticSubjectMapping(GetExternalSource):
         """
         for p in self.primary_subjects:
             for s in p.secondary_subjects:
-                if s.statistic_short_names_primary.get(statistic_short_name):
+                if statistic_short_name in s.statistic_short_names:
                     logger.debug("Got %s from %s", s, statistic_short_name)
                     return s.subject_code
 
@@ -140,11 +140,11 @@ class StatisticSubjectMapping(GetExternalSource):
                 SecondarySubject(
                     self._extract_titles(s.titler),
                     s["emnekode"],
-                    {
-                        statistikk["kortnavn"]: statistikk["isPrimaerPlassering"]
-                        == "true"
+                    [
+                        statistikk["kortnavn"]
                         for statistikk in s.find_all("Statistikk")
-                    },
+                        if statistikk["isPrimaerPlassering"] == "true"
+                    ],
                 )
                 for s in p.find_all("delemne")
             ]

--- a/tests/datasets/resources/statistical_subject_structure/extract_secondary_subject.xml
+++ b/tests/datasets/resources/statistical_subject_structure/extract_secondary_subject.xml
@@ -53,7 +53,7 @@
                     <tittel sprak="no">ab00 norwegian</tittel>
                     <tittel sprak="en">ab00 english</tittel>
                 </titler>
-                <Statistikk kortnavn="ab_kortnvan" isPrimaerPlassering="false">
+                <Statistikk kortnavn="ab_kortnvan" isPrimaerPlassering="true">
                     <titler>
                         <tittel sprak="no">ab_kortnvan norwegian</tittel>
                         <tittel sprak="en">ab_kortnvan english</tittel>

--- a/tests/datasets/resources/statistical_subject_structure/extract_secondary_subject.xml
+++ b/tests/datasets/resources/statistical_subject_structure/extract_secondary_subject.xml
@@ -30,6 +30,18 @@
                     </titler>
                 </Statistikk>
             </delemne>
+            <delemne emnekode="aa02">
+                <titler>
+                    <tittel sprak="no">ab01 norwegian</tittel>
+                    <tittel sprak="en">ab01 english</tittel>
+                </titler>
+                <Statistikk kortnavn="ab_kortnvan_01" isPrimaerPlassering="false">
+                    <titler>
+                        <tittel sprak="no">ab_kortnvan norwegian</tittel>
+                        <tittel sprak="en">ab_kortnvan english</tittel>
+                    </titler>
+                </Statistikk>
+            </delemne>
         </hovedemne>
         <hovedemne emnekode="ab">
             <titler>

--- a/tests/datasets/resources/statistical_subject_structure/extract_secondary_subject.xml
+++ b/tests/datasets/resources/statistical_subject_structure/extract_secondary_subject.xml
@@ -53,7 +53,7 @@
                     <tittel sprak="no">ab00 norwegian</tittel>
                     <tittel sprak="en">ab00 english</tittel>
                 </titler>
-                <Statistikk kortnavn="ab_kortnvan" isPrimaerPlassering="true">
+                <Statistikk kortnavn="ab_kortnvan" isPrimaerPlassering="false">
                     <titler>
                         <tittel sprak="no">ab_kortnvan norwegian</tittel>
                         <tittel sprak="en">ab_kortnvan english</tittel>

--- a/tests/datasets/test_statistic_subject_mapping.py
+++ b/tests/datasets/test_statistic_subject_mapping.py
@@ -39,8 +39,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                         SecondarySubject(
                             titles={"en": "aa00 english", "no": "aa00 norwegian"},
                             subject_code="aa00",
-                            statistic_short_names=["aa_kortnvan"],
-                            primary_placement={"aa_kortnvan": True},
+                            statistic_short_names_primary={"aa_kortnvan": True},
                         ),
                     ],
                 ),
@@ -63,24 +62,18 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                     secondary_subjects=[
                         SecondarySubject(
                             titles={
-                                "en": "aa00 english",
                                 "no": "aa00 norwegian",
+                                "en": "aa00 english",
                             },
                             subject_code="aa00",
-                            statistic_short_names=[
-                                "aa_kortnvan",
-                            ],
-                            primary_placement={"aa_kortnvan": True},
+                            statistic_short_names_primary={"aa_kortnvan": True},
                         ),
                         SecondarySubject(
                             titles={
                                 "no": "aa01 norwegian",
                             },
                             subject_code="aa01",
-                            statistic_short_names=[
-                                "aa_kortnvan_01",
-                            ],
-                            primary_placement={"aa_kortnvan_01": True},
+                            statistic_short_names_primary={"aa_kortnvan_01": True},
                         ),
                     ],
                 ),
@@ -92,24 +85,18 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                     secondary_subjects=[
                         SecondarySubject(
                             titles={
-                                "en": "ab00 english",
                                 "no": "ab00 norwegian",
+                                "en": "ab00 english",
                             },
                             subject_code="ab00",
-                            statistic_short_names=[
-                                "ab_kortnvan",
-                            ],
-                            primary_placement={"ab_kortnvan": True},
+                            statistic_short_names_primary={"ab_kortnvan": True},
                         ),
                         SecondarySubject(
                             titles={
                                 "en": "ab01 english",
                             },
                             subject_code="ab01",
-                            statistic_short_names=[
-                                "ab_kortnvan_01",
-                            ],
-                            primary_placement={"ab_kortnvan_01": True},
+                            statistic_short_names_primary={"ab_kortnvan_01": True},
                         ),
                     ],
                 ),

--- a/tests/datasets/test_statistic_subject_mapping.py
+++ b/tests/datasets/test_statistic_subject_mapping.py
@@ -40,7 +40,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             titles={"en": "aa00 english", "no": "aa00 norwegian"},
                             subject_code="aa00",
                             statistic_short_names=["aa_kortnvan"],
-                            primary_placement={"aa_kortnvan": True}
+                            primary_placement={"aa_kortnvan": True},
                         ),
                     ],
                 ),
@@ -70,7 +70,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             statistic_short_names=[
                                 "aa_kortnvan",
                             ],
-                            primary_placement={"aa_kortnvan": True}
+                            primary_placement={"aa_kortnvan": True},
                         ),
                         SecondarySubject(
                             titles={
@@ -80,7 +80,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             statistic_short_names=[
                                 "aa_kortnvan_01",
                             ],
-                            primary_placement={"aa_kortnvan_01": True}
+                            primary_placement={"aa_kortnvan_01": True},
                         ),
                     ],
                 ),
@@ -99,7 +99,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             statistic_short_names=[
                                 "ab_kortnvan",
                             ],
-                            primary_placement={"ab_kortnvan": True}
+                            primary_placement={"ab_kortnvan": True},
                         ),
                         SecondarySubject(
                             titles={
@@ -109,7 +109,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             statistic_short_names=[
                                 "ab_kortnvan_01",
                             ],
-                            primary_placement={"ab_kortnvan_01": True}
+                            primary_placement={"ab_kortnvan_01": True},
                         ),
                     ],
                 ),

--- a/tests/datasets/test_statistic_subject_mapping.py
+++ b/tests/datasets/test_statistic_subject_mapping.py
@@ -40,6 +40,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             titles={"en": "aa00 english", "no": "aa00 norwegian"},
                             subject_code="aa00",
                             statistic_short_names=["aa_kortnvan"],
+                            primary_placement={"aa_kortnvan": True}
                         ),
                     ],
                 ),
@@ -69,6 +70,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             statistic_short_names=[
                                 "aa_kortnvan",
                             ],
+                            primary_placement={"aa_kortnvan": True}
                         ),
                         SecondarySubject(
                             titles={
@@ -78,6 +80,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             statistic_short_names=[
                                 "aa_kortnvan_01",
                             ],
+                            primary_placement={"aa_kortnvan_01": True}
                         ),
                     ],
                 ),
@@ -96,6 +99,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             statistic_short_names=[
                                 "ab_kortnvan",
                             ],
+                            primary_placement={"ab_kortnvan": True}
                         ),
                         SecondarySubject(
                             titles={
@@ -105,6 +109,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                             statistic_short_names=[
                                 "ab_kortnvan_01",
                             ],
+                            primary_placement={"ab_kortnvan_01": True}
                         ),
                     ],
                 ),

--- a/tests/datasets/test_statistic_subject_mapping.py
+++ b/tests/datasets/test_statistic_subject_mapping.py
@@ -39,7 +39,7 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                         SecondarySubject(
                             titles={"en": "aa00 english", "no": "aa00 norwegian"},
                             subject_code="aa00",
-                            statistic_short_names_primary={"aa_kortnvan": True},
+                            statistic_short_names=["aa_kortnvan"],
                         ),
                     ],
                 ),
@@ -66,14 +66,14 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                                 "en": "aa00 english",
                             },
                             subject_code="aa00",
-                            statistic_short_names_primary={"aa_kortnvan": True},
+                            statistic_short_names=["aa_kortnvan"],
                         ),
                         SecondarySubject(
                             titles={
                                 "no": "aa01 norwegian",
                             },
                             subject_code="aa01",
-                            statistic_short_names_primary={"aa_kortnvan_01": True},
+                            statistic_short_names=["aa_kortnvan_01"],
                         ),
                     ],
                 ),
@@ -89,14 +89,14 @@ STATISTICAL_SUBJECT_STRUCTURE_DIR = "statistical_subject_structure"
                                 "en": "ab00 english",
                             },
                             subject_code="ab00",
-                            statistic_short_names_primary={"ab_kortnvan": True},
+                            statistic_short_names=["ab_kortnvan"],
                         ),
                         SecondarySubject(
                             titles={
                                 "en": "ab01 english",
                             },
                             subject_code="ab01",
-                            statistic_short_names_primary={"ab_kortnvan_01": True},
+                            statistic_short_names=["ab_kortnvan_01"],
                         ),
                     ],
                 ),


### PR DESCRIPTION
Reported by @aosthus 
Current Datadoc does not take into account the "isPrimaerPlassering" flag in th XML from Mimir.
This places the Shortname in the wrong Subjects when the Shortname is in multiple Subjects.

This PR just filters down to the first true "primary placement", after a check all shortnames have at least on primary placement, but some have multiple.