### PR TITLE
Remove a pseudo variable

### DIFF
--- a/src/dapla_metadata/datasets/core.py
+++ b/src/dapla_metadata/datasets/core.py
@@ -629,11 +629,41 @@ class Datadoc:
         return calculate_percentage(num_set_fields, num_all_fields)
 
     def add_pseudo_variable(self, variable_short_name: str) -> None:
-        """Adds a new pseudo variable to the list of pseudonymized variables."""
+        """Adds a new pseudo variable to the list of pseudonymized variables.
+
+        Sets is_personal_data to pseudonymized encrypted personal data.
+        """
         if self.variables_lookup[variable_short_name] is not None:
             pseudo_variable = model.PseudoVariable(short_name=variable_short_name)
             self.pseudo_variables.append(pseudo_variable)
             self.pseudo_variables_lookup[variable_short_name] = pseudo_variable
+            self.variables_lookup[
+                variable_short_name
+            ].is_personal_data = (
+                model.IsPersonalData.PSEUDONYMISED_ENCRYPTED_PERSONAL_DATA
+            )
+
+    def remove_pseudo_variable(self, variable_short_name: str) -> None:
+        """Removes a pseudo variable by using the shortname.
+
+        Updates the pseudo variable lookup by creating a new one.
+        Sets is_personal_data to non pseudonymized encrypted personal data.
+        """
+        if self.pseudo_variables_lookup[variable_short_name] is not None:
+            pseudo_variable = self.get_pseudo_variable(variable_short_name)
+
+            if pseudo_variable is not None:
+                self.pseudo_variables = [
+                    pseudo_variable
+                    for pseudo_variable in self.pseudo_variables
+                    if pseudo_variable.short_name != variable_short_name
+                ]
+            self._create_pseudo_variables_lookup()
+            self.variables_lookup[
+                variable_short_name
+            ].is_personal_data = (
+                model.IsPersonalData.NON_PSEUDONYMISED_ENCRYPTED_PERSONAL_DATA
+            )
 
     def get_pseudo_variable(
         self, variable_short_name: str

--- a/tests/datasets/test_datadoc_metadata.py
+++ b/tests/datasets/test_datadoc_metadata.py
@@ -915,9 +915,14 @@ def test_add_pseudo_variable(
     existing_metadata_file: Path,  # noqa: ARG001
     metadata: Datadoc,
 ):
+    test_variable = "sykepenger"
     assert len(metadata.pseudo_variables) == 2
-    metadata.add_pseudo_variable("sykepenger")
+    metadata.add_pseudo_variable(test_variable)
     assert len(metadata.pseudo_variables) == 3
+    assert (
+        metadata.variables_lookup[test_variable].is_personal_data
+        is IsPersonalData.PSEUDONYMISED_ENCRYPTED_PERSONAL_DATA.value
+    )
 
 
 @pytest.mark.parametrize(
@@ -959,3 +964,35 @@ def test_open_pseudo_with_no_variables(
     metadata: Datadoc,
 ):
     assert metadata.pseudo_variables == []
+
+
+@pytest.mark.parametrize(
+    "existing_metadata_path",
+    [TEST_PSEUDO_DIRECTORY / "dataset_and_pseudo"],
+)
+def test_remove_pseudo_variable(
+    existing_metadata_file: Path,  # noqa: ARG001
+    metadata: Datadoc,
+):
+    test_variable = "alm_inntekt"
+    assert len(metadata.pseudo_variables) == 2
+    metadata.remove_pseudo_variable(test_variable)
+    assert len(metadata.pseudo_variables) == 1
+    assert (
+        metadata.variables_lookup[test_variable].is_personal_data
+        is IsPersonalData.NON_PSEUDONYMISED_ENCRYPTED_PERSONAL_DATA.value
+    )
+
+
+@pytest.mark.parametrize(
+    "existing_metadata_path",
+    [TEST_PSEUDO_DIRECTORY / "dataset_and_pseudo"],
+)
+def test_remove_pseudo_variable_non_existent_variable_name(
+    existing_metadata_file: Path,  # noqa: ARG001
+    metadata: Datadoc,
+):
+    assert len(metadata.pseudo_variables) == 2
+    with pytest.raises(KeyError):
+        metadata.remove_pseudo_variable("fnr")
+    assert len(metadata.pseudo_variables) == 2


### PR DESCRIPTION
- Method that allows for the removal of a pseudo variable
- When adding a pseudo variable is_personal_data is set to PSEUDONYMISED_ENCRYPTED_PERSONAL_DATA
- When removing a pseudo variable is_personal_data is set to NON_PSEUDONYMISED_ENCRYPTED_PERSONAL_DATA