### PR TITLE
change link to klass

### DIFF
--- a/demo/variable_definitions/ny_variabeldefinisjon.ipynb
+++ b/demo/variable_definitions/ny_variabeldefinisjon.ipynb
@@ -54,7 +54,7 @@
     "Noen av disse feltene er forhåndsutfylt med eksempelverdier, noen verdier settes av systemet mens andre er **maskingenererte** og skal ikke **redigeres**.\n",
     "\n",
     "🔗 Her finner du lenker til kodelister og klassifikasjoner i Klass som brukes for å fylle ut feltene:\n",
-    "- [klassifikasjonsreferanse(`classification_reference`)](https://www.ssb.no/klass/klassifikasjoner)\n",
+    "- [klassifikasjonsreferanse(`classification_reference`)](https://www.ssb.no/klass)\n",
     "- [enhetstyper (`unit_types`)](https://www.ssb.no/klass/klassifikasjoner/702) \n",
     "- [statistikkområder (`subject_fields`)](https://www.ssb.no/klass/klassifikasjoner/618)\n",
     "- [måletype(`measurement_type`)](https://www.ssb.no/klass/klassifikasjoner/303)"

--- a/demo/variable_definitions/rediger_publisert_variabeldefinisjon.ipynb
+++ b/demo/variable_definitions/rediger_publisert_variabeldefinisjon.ipynb
@@ -66,7 +66,7 @@
     "💡Se notebooken `ny_gyldighetsperiode_variabeldefinisjon` for hvordan dette gjøres.\n",
     "\n",
     "🔗 Her finner du lenker til kodelister og klassifikasjoner i Klass som brukes for å fylle ut feltene:\n",
-    "- [klassifikasjonsreferanse(`classification_reference`)](https://www.ssb.no/klass/klassifikasjoner)\n",
+    "- [klassifikasjonsreferanse(`classification_reference`)](https://www.ssb.no/klass)\n",
     "- [enhetstyper (`unit_types`)](https://www.ssb.no/klass/klassifikasjoner/702) \n",
     "- [statistikkområder (`subject_fields`)](https://www.ssb.no/klass/klassifikasjoner/618)\n",
     "- [måletype(`measurement_type`)](https://www.ssb.no/klass/klassifikasjoner/303)"

--- a/demo/variable_definitions/rediger_utkast_variabeldefinisjon.ipynb
+++ b/demo/variable_definitions/rediger_utkast_variabeldefinisjon.ipynb
@@ -55,7 +55,7 @@
     "## Viktig informasjon\n",
     "\n",
     "🔗 Her finner du lenker til kodelister og klassifikasjoner i Klass som brukes for å fylle ut feltene:\n",
-    "- [klassifikasjonsreferanse(`classification_reference`)](https://www.ssb.no/klass/klassifikasjoner)\n",
+    "- [klassifikasjonsreferanse(`classification_reference`)](https://www.ssb.no/klass)\n",
     "- [enhetstyper (`unit_types`)](https://www.ssb.no/klass/klassifikasjoner/702) \n",
     "- [statistikkområder (`subject_fields`)](https://www.ssb.no/klass/klassifikasjoner/618)\n",
     "- [måletype(`measurement_type`)](https://www.ssb.no/klass/klassifikasjoner/303)"


### PR DESCRIPTION
Link was to 'https://www.ssb.no/klass/klassifikasjoner' which doesn't make sense if you don't have an id, so changed link to 'https://www.ssb.no/klass/' where all "klassifikasjon" can be found