### PR TITLE
Disable publish variable definitions in production environment

### DIFF
--- a/src/dapla_metadata/variable_definitions/_utils/constants.py
+++ b/src/dapla_metadata/variable_definitions/_utils/constants.py
@@ -60,3 +60,7 @@ DOUBLE_QUOTE_FIELDS = [
     "id",
     "last_updated_by",
 ]
+
+PUBLISHING_BLOCKED_ERROR_MESSAGE = "Publishing blocked: Publishing variable definitions is not allowed until further notice."
+VARDEF_PROD_URL = "https://metadata.intern.ssb.no"
+VARDEF_TEST_URL = "https://metadata.intern.test.ssb.no"

--- a/src/dapla_metadata/variable_definitions/exceptions.py
+++ b/src/dapla_metadata/variable_definitions/exceptions.py
@@ -229,6 +229,16 @@ def publishing_blocked_error_handler(method):  # noqa: ANN201, ANN001
             raise RuntimeError(msg) from e
 
         if host == vardef_prod:
+            if len(method_args) > 1:
+                status = method_args[1].variable_status
+                if status == "DRAFT":
+                    return method(
+                        *method_args,
+                        **method_kwargs,
+                    )
+                if status in ("PUBLISHED_INTERNAL", "PUBLISHED_EXTERNAL"):
+                    msg = "Prod is blocked"
+                    raise PublishingBlockedError(msg)
             msg = "Prod is blocked"
             raise PublishingBlockedError(msg)
         return method(

--- a/src/dapla_metadata/variable_definitions/exceptions.py
+++ b/src/dapla_metadata/variable_definitions/exceptions.py
@@ -15,6 +15,7 @@ from dapla_metadata.variable_definitions._generated.vardef_client.exceptions imp
 from dapla_metadata.variable_definitions._generated.vardef_client.exceptions import (
     UnauthorizedException,
 )
+from dapla_metadata.variable_definitions._utils._client import VardefClient
 
 # Use MappingProxyType so the dict is immutable
 STATUS_EXPLANATIONS: MappingProxyType[HTTPStatus | None, str] = MappingProxyType(
@@ -192,5 +193,47 @@ def vardef_file_error_handler(method):  # noqa: ANN201, ANN001
         except NotADirectoryError as e:
             msg = f"Path is not a directory: {method_kwargs.get('file_path', 'unknown file path')}. Original error: {e!s}"
             raise VardefFileError(msg) from e
+
+    return _impl
+
+
+class PublishingBlockedError(RuntimeError):
+    """Custom exception for handling publishing is not allowed in prod environment.
+
+    Attributes:
+        message (str): Message describing the error.
+    """
+
+    def __init__(self, message: str, *args) -> None:  # noqa: ANN002
+        """Accepting the message and any additional arguments."""
+        super().__init__(*args)
+        self.message = message
+        self.args = args
+
+    def __str__(self) -> str:
+        """Returning a custom string representation of the exception."""
+        return f"Publishing blocked: {self.message}"
+
+
+def publishing_blocked_error_handler(method):  # noqa: ANN201, ANN001
+    """Decorator for handling exceptions publish variable definitions."""
+
+    @wraps(method)
+    def _impl(*method_args, **method_kwargs):  # noqa: ANN002, ANN003
+        vardef_prod = "https://metadata.intern.ssb.no"
+        try:
+            client = VardefClient()
+            host = client.get_config().host
+        except VardefClientError as e:
+            msg = f"Failed to get VardefClient config: {e}"
+            raise RuntimeError(msg) from e
+
+        if host == vardef_prod:
+            msg = "Prod is blocked"
+            raise PublishingBlockedError(msg)
+        return method(
+            *method_args,
+            **method_kwargs,
+        )
 
     return _impl

--- a/src/dapla_metadata/variable_definitions/exceptions.py
+++ b/src/dapla_metadata/variable_definitions/exceptions.py
@@ -217,8 +217,11 @@ class PublishingBlockedError(RuntimeError):
 def publishing_blocked_error_handler(method):  # noqa: ANN201, ANN001
     """Decorator that blocks publishing variable definitions in production.
 
-    If the environment is production and the variable status
-    is not `DRAFT`, a `PublishingBlockedError` is raised.
+    - If the environment is production:
+        - If `variable_status` is present in the arguments and set to `PUBLISHED_INTERNAL` or `PUBLISHED_EXTERNAL`,
+        publishing is blocked by raising a `PublishingBlockedError`.
+        - If `variable_status` is set to `DRAFT`, the method is allowed to proceed.
+        - If no arguments are provided, all publishing attempts are blocked.
     """
 
     @wraps(method)

--- a/src/dapla_metadata/variable_definitions/variable_definition.py
+++ b/src/dapla_metadata/variable_definitions/variable_definition.py
@@ -41,6 +41,9 @@ from dapla_metadata.variable_definitions._utils.variable_definition_files import
 from dapla_metadata.variable_definitions._utils.variable_definition_files import (
     create_variable_yaml,
 )
+from dapla_metadata.variable_definitions.exceptions import (
+    publishing_blocked_error_handler,
+)
 from dapla_metadata.variable_definitions.exceptions import vardef_exception_handler
 from dapla_metadata.variable_definitions.exceptions import vardef_file_error_handler
 
@@ -340,6 +343,7 @@ class VariableDefinition(CompleteResponse):
             ),
         )
 
+    @publishing_blocked_error_handler
     def publish_internal(self) -> "VariableDefinition":
         """Publish this variable definition internally."""
         if self.variable_status != VariableStatus.DRAFT.name:
@@ -358,6 +362,7 @@ class VariableDefinition(CompleteResponse):
         )
         return update
 
+    @publishing_blocked_error_handler
     def publish_external(self) -> "VariableDefinition":
         """Publish this variable definition externally."""
         if self.variable_status == VariableStatus.PUBLISHED_EXTERNAL.name:

--- a/src/dapla_metadata/variable_definitions/variable_definition.py
+++ b/src/dapla_metadata/variable_definitions/variable_definition.py
@@ -102,6 +102,7 @@ class VariableDefinition(CompleteResponse):
             )
         ]
 
+    @publishing_blocked_error_handler
     @vardef_exception_handler
     def update_draft(
         self,

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -465,8 +465,9 @@ def test_block_publish_methods(
 
     client = VardefClient()
     config = client.get_config()
-
+    assert config is not None
     assert config.host == mocked_host
+
     variable_definition.variable_status = initial_status
 
     method = getattr(variable_definition, method_name)
@@ -528,7 +529,7 @@ def test_block_update_variable_status(
 
     client = VardefClient()
     config = client.get_config()
-
+    assert config is not None
     assert config.host == mocked_host
 
     variable_definition.variable_status = VariableStatus.DRAFT

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -375,6 +375,68 @@ def test_publish_methods(
         )
 
 
+def test_str(variable_definition):
+    assert (
+        str(variable_definition)
+        == """id: "wypvb3wd"
+patch_id: 1
+name:
+    nb: |-
+        test
+    nn: |-
+        test
+    en: |-
+        test
+short_name: "var_test"
+definition:
+    nb: |-
+        test
+    nn: |-
+        test
+    en: |-
+        test
+classification_reference: "91"
+unit_types:
+    - "01"
+subject_fields:
+    - "a"
+    - "b"
+contains_special_categories_of_personal_data: true
+variable_status: PUBLISHED_EXTERNAL
+measurement_type: "test"
+valid_from: '2024-11-01'
+valid_until:
+external_reference_uri: "http://www.example.com"
+comment:
+    nb: |-
+        test
+    nn: |-
+        test
+    en: |-
+        test
+related_variable_definition_uris:
+    - "http://www.example.com"
+owner:
+    team: "my_team"
+    groups:
+        - "my_team_developers"
+contact:
+    title:
+        nb: |-
+            test
+        nn: |-
+            test
+        en: |-
+            test
+    email: me@example.com
+created_at: '2024-11-01T00:00:00'
+created_by: "ano@ssb.no"
+last_updated_at: '2024-11-01T00:00:00'
+last_updated_by: "ano@ssb.no"
+"""
+    )
+
+
 @pytest.mark.parametrize("method_name", ["publish_internal", "publish_external"])
 @pytest.mark.parametrize(
     ("mocked_host", "should_raise"),
@@ -487,65 +549,3 @@ def test_block_update_variable_status(
             except ValueError:
                 # Ignore other exceptions for publishing
                 contextlib.suppress(ValueError)
-
-
-def test_str(variable_definition):
-    assert (
-        str(variable_definition)
-        == """id: "wypvb3wd"
-patch_id: 1
-name:
-    nb: |-
-        test
-    nn: |-
-        test
-    en: |-
-        test
-short_name: "var_test"
-definition:
-    nb: |-
-        test
-    nn: |-
-        test
-    en: |-
-        test
-classification_reference: "91"
-unit_types:
-    - "01"
-subject_fields:
-    - "a"
-    - "b"
-contains_special_categories_of_personal_data: true
-variable_status: PUBLISHED_EXTERNAL
-measurement_type: "test"
-valid_from: '2024-11-01'
-valid_until:
-external_reference_uri: "http://www.example.com"
-comment:
-    nb: |-
-        test
-    nn: |-
-        test
-    en: |-
-        test
-related_variable_definition_uris:
-    - "http://www.example.com"
-owner:
-    team: "my_team"
-    groups:
-        - "my_team_developers"
-contact:
-    title:
-        nb: |-
-            test
-        nn: |-
-            test
-        en: |-
-            test
-    email: me@example.com
-created_at: '2024-11-01T00:00:00'
-created_by: "ano@ssb.no"
-last_updated_at: '2024-11-01T00:00:00'
-last_updated_by: "ano@ssb.no"
-"""
-    )

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -382,10 +382,10 @@ def test_publish_methods(
 @patch.object(VariableDefinition, "update_draft")
 @patch.object(VariableDefinition, "create_patch")
 @patch("dapla_metadata.variable_definitions._utils._client.VardefClient.get_config")
-def test_blocked_publish_methods(
+def test_block_publish_methods(
     mock_get_config: MagicMock,
-    mock_update_draft: MagicMock,  # noqa: ARG001
-    mock_create_patch: MagicMock,  # noqa: ARG001
+    mock_update_draft: MagicMock,
+    mock_create_patch: MagicMock,
     method_name: str,
     mocked_host: str,
     should_raise: bool,
@@ -408,10 +408,13 @@ def test_blocked_publish_methods(
             PublishingBlockedError, match="Publishing blocked: Prod is blocked"
         ):
             method()
+        mock_update_draft.assert_not_called()
+        mock_create_patch.assert_not_called()
 
     else:
         try:
             method()
+            assert mock_update_draft.called() or mock_create_patch.called()
         except ValueError:
             # Ignore other exceptions for publishing
             contextlib.suppress(ValueError)
@@ -444,7 +447,7 @@ def test_blocked_publish_methods(
     ],
 )
 @patch("dapla_metadata.variable_definitions._utils._client.VardefClient.get_config")
-def test_block_publishing_from_draft(
+def test_block_update_variable_status(
     mock_get_config: MagicMock,
     mocked_host: str,
     update_status,

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -413,7 +413,7 @@ def test_blocked_publish_methods(
         try:
             method()
         except ValueError:
-            # This is expected for invalid statuses
+            # Ignore other exceptions for publishing
             contextlib.suppress(ValueError)
 
 

--- a/tests/variable_definitions/test_variable_definition.py
+++ b/tests/variable_definitions/test_variable_definition.py
@@ -19,6 +19,11 @@ from dapla_metadata.variable_definitions._generated.vardef_client.models.variabl
     VariableStatus,
 )
 from dapla_metadata.variable_definitions._utils._client import VardefClient
+from dapla_metadata.variable_definitions._utils.constants import (
+    PUBLISHING_BLOCKED_ERROR_MESSAGE,
+)
+from dapla_metadata.variable_definitions._utils.constants import VARDEF_PROD_URL
+from dapla_metadata.variable_definitions._utils.constants import VARDEF_TEST_URL
 from dapla_metadata.variable_definitions.exceptions import PublishingBlockedError
 from dapla_metadata.variable_definitions.exceptions import VardefFileError
 from dapla_metadata.variable_definitions.vardef import Vardef
@@ -405,7 +410,7 @@ def test_block_publish_methods(
     method = getattr(variable_definition, method_name)
     if should_raise:
         with pytest.raises(
-            PublishingBlockedError, match="Publishing blocked: Prod is blocked"
+            PublishingBlockedError, match=PUBLISHING_BLOCKED_ERROR_MESSAGE
         ):
             method()
         mock_update_draft.assert_not_called()
@@ -414,7 +419,7 @@ def test_block_publish_methods(
     else:
         try:
             method()
-            assert mock_update_draft.called() or mock_create_patch.called()
+            assert mock_update_draft.called or mock_create_patch.called
         except ValueError:
             # Ignore other exceptions for publishing
             contextlib.suppress(ValueError)
@@ -424,23 +429,24 @@ def test_block_publish_methods(
     ("mocked_host", "update_status", "should_raise"),
     [
         (
-            "https://metadata.intern.ssb.no",
+            VARDEF_PROD_URL,
             VariableStatus.PUBLISHED_INTERNAL.value,
             True,
         ),
         (
-            "https://metadata.intern.ssb.no",
+            VARDEF_PROD_URL,
             VariableStatus.PUBLISHED_EXTERNAL.value,
             True,
         ),
-        ("https://metadata.intern.ssb.no", VariableStatus.DRAFT.value, False),
+        (VARDEF_PROD_URL, VariableStatus.DRAFT.value, False),
+        (VARDEF_TEST_URL, VariableStatus.DRAFT.value, False),
         (
-            "https://metadata.intern.test.ssb.no",
+            VARDEF_TEST_URL,
             VariableStatus.PUBLISHED_INTERNAL.value,
             False,
         ),
         (
-            "https://metadata.intern.test.ssb.no",
+            VARDEF_TEST_URL,
             VariableStatus.PUBLISHED_EXTERNAL.value,
             False,
         ),
@@ -472,7 +478,7 @@ def test_block_update_variable_status(
 
         if should_raise:
             with pytest.raises(
-                PublishingBlockedError, match="Publishing blocked: Prod is blocked"
+                PublishingBlockedError, match=PUBLISHING_BLOCKED_ERROR_MESSAGE
             ):
                 variable_definition.update_draft(update)
         else:


### PR DESCRIPTION
Ref: https://statistics-norway.atlassian.net/browse/DPMETA-937

Introduce a custom exception `PublishingBlockedError` along with a decorator (`publishing_blocked_error_handler`) to temporarily block publishing of variable definitions in the production environment.

The decorator should be applied to publish-related methods. It blocks publishing when the `variable_status` is set to `PUBLISHED_INTERNAL` or `PUBLISHED_EXTERNAL`.

It allows `DRAFT` status to pass through in `update_draft`, so other modifications to a draft are not unintentionally blocked.

The decorator is also applied to higher-level methods that call `update_draft`, to ensure the publishing block is enforced immediately—before any further processing or validation.
