### PR TITLE
Suppress warning from dapla-auth-client

### DIFF
--- a/src/dapla_metadata/variable_definitions/_utils/config.py
+++ b/src/dapla_metadata/variable_definitions/_utils/config.py
@@ -3,6 +3,7 @@ import warnings
 # TODO @mmwinther: https://github.com/statisticsnorway/dapla-auth-client/issues/29
 # Remove catch_warnings when this issue is resolved
 with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
     from dapla_auth_client import AuthClient
 
 from dapla_metadata._shared.config import get_config_item
@@ -46,6 +47,7 @@ def refresh_access_token() -> str:
     # TODO @mmwinther: https://github.com/statisticsnorway/dapla-auth-client/issues/29
     # Remove catch_warnings when this issue is resolved
     with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         return AuthClient.fetch_personal_token(
             scopes=["all_groups", "current_group"], audiences=["vardef"]
         )


### PR DESCRIPTION
This warning appeared in Notebooks when importing anything from `variable_definitions` as well as every time a request was made, since we call `dapla_auth_client` code each time. Quite irritating for users.

Ref: DPMETA-1156