### PR TITLE
Fix Vardef ID validation

### DIFF
--- a/src/dapla_metadata/datasets/utility/urn.py
+++ b/src/dapla_metadata/datasets/utility/urn.py
@@ -170,7 +170,7 @@ class UrnConverter:
 
 vardef_urn_converter = UrnConverter(
     urn_base="urn:ssb:variable-definition:vardef",
-    id_pattern=r"([a-z0-9]{8})",
+    id_pattern=r"([a-zA-Z0-9-_]{8})",  # 8 character Nanoid with default alphabet
     url_bases=[
         *[
             (

--- a/tests/datasets/test_urn.py
+++ b/tests/datasets/test_urn.py
@@ -15,7 +15,7 @@ from dapla_metadata.datasets.utility.urn import vardef_urn_converter
 
 EXAMPLE_KLASS_ID = "91"
 EXAMPLE_KLASS_URN = AnyUrl(klass_urn_converter.get_urn(EXAMPLE_KLASS_ID))
-EXAMPLE_VARDEF_ID = "hd8sks89"
+EXAMPLE_VARDEF_ID = "hd8_Ks-9"
 EXAMPLE_VARDEF_URN = AnyUrl(vardef_urn_converter.get_urn(EXAMPLE_VARDEF_ID))
 
 VARIABLE_DEFINITION_URN_TEST_CASES = [
@@ -141,7 +141,7 @@ def test_vardef_get_id(urn_or_url: str | AnyUrl, identifier: str | None):
         ("123", False),
         ("12345678", True),
         ("123456789", False),
-        ("abcdEFGH", False),
+        ("abc$EFGH", False),
         ("", False),
         (None, False),
     ],


### PR DESCRIPTION
The alphabet for Nanoid is larger than the character set we
were checking for here. This corrects the regex and adds more
representative test cases.
