### PR TITLE
Add Statistics for Migrated Variable Definitions

### DIFF
--- a/demo/variable_definitions/sjekk_migrerte_variabeldefinisjoner.ipynb
+++ b/demo/variable_definitions/sjekk_migrerte_variabeldefinisjoner.ipynb
@@ -35,6 +35,7 @@
     "import sys\n",
     "\n",
     "from dapla_metadata.variable_definitions import Vardef\n",
+    "from dapla_metadata.variable_definitions import models\n",
     "\n",
     "# Redusere størrelsen på Traceback for mer tydelige feilmeldinger\n",
     "%xmode Minimal\n",
@@ -165,6 +166,122 @@
     ")\n",
     "\n",
     "min_variabel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Statistikk migrerte variabeldefinisjoner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Oppsett"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variabel_definisjoner = Vardef.list_variable_definitions()\n",
+    "vardef_ids = {v.vardef_id for v in Vardef.list_vardok_vardef_mapping()}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Migrert utkast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variabel_definisjoner_utkast = [\n",
+    "    variabel\n",
+    "    for variabel in variabel_definisjoner\n",
+    "    if variabel.variable_status == models.VariableStatus.DRAFT\n",
+    "]\n",
+    "\n",
+    "migrerte_utkast = [\n",
+    "    variabel for variabel in variabel_definisjoner_utkast if variabel.id in vardef_ids\n",
+    "]\n",
+    "\n",
+    "generert_kortnavn = [\n",
+    "    variabel\n",
+    "    for variabel in variabel_definisjoner_utkast\n",
+    "    if variabel.short_name.lower().startswith(\"generert\")\n",
+    "]\n",
+    "\n",
+    "print(\"Antall utkast:\", len(variabel_definisjoner_utkast))\n",
+    "print(\"Antall migrerte utkast:\", len(migrerte_utkast))\n",
+    "print(\"Antall med generert kortnavn:\", len(generert_kortnavn))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Migrert publisert internt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variabel_definisjoner_publisert_internt = [\n",
+    "    variabel\n",
+    "    for variabel in variabel_definisjoner\n",
+    "    if variabel.variable_status == models.VariableStatus.PUBLISHED_INTERNAL\n",
+    "]\n",
+    "\n",
+    "migrerte_publisert_internt = [\n",
+    "    variabel\n",
+    "    for variabel in variabel_definisjoner_publisert_internt\n",
+    "    if variabel.id in vardef_ids\n",
+    "]\n",
+    "\n",
+    "print(\"Antall publisert internt:\", len(variabel_definisjoner_publisert_internt))\n",
+    "print(\"Antall migrerte publisert internt:\", len(migrerte_publisert_internt))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Migrert publisert eksternt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variabel_definisjoner_publisert_eksternt = [\n",
+    "    variabel\n",
+    "    for variabel in variabel_definisjoner\n",
+    "    if variabel.variable_status == models.VariableStatus.PUBLISHED_EXTERNAL\n",
+    "]\n",
+    "\n",
+    "migrerte_publisert_eksternt = [\n",
+    "    variabel\n",
+    "    for variabel in variabel_definisjoner_publisert_eksternt\n",
+    "    if variabel.id in vardef_ids\n",
+    "]\n",
+    "\n",
+    "print(\"Antall publisert eksternt:\", len(variabel_definisjoner_publisert_eksternt))\n",
+    "print(\"Antall migrerte publisert eksternt:\", len(migrerte_publisert_eksternt))"
    ]
   }
  ],


### PR DESCRIPTION
Add statistics to the `sjekk_migrerte_variabeldefinisjoner` notebook to provide an overview and support decision-making during the migration from Vardok to Vardef.